### PR TITLE
[FEAT/#5] 청첩장 상품 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
+++ b/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.marimo.server.domain.product.controller;
 
 import com.marimo.server.domain.product.dto.BannerListResponse;
+import com.marimo.server.domain.product.dto.InvitationListResponse;
 import com.marimo.server.domain.product.enums.ProductType;
 import com.marimo.server.domain.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,13 @@ public class ProductController {
 
         return ResponseEntity.ok(
                 productService.fetchBanners(productType)
+        );
+    }
+
+    @GetMapping(path = "invitations", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<InvitationListResponse> getInvitations() {
+        return ResponseEntity.ok(
+                productService.fetchInvitations()
         );
     }
 }

--- a/src/main/java/com/marimo/server/domain/product/dto/InvitationListResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/InvitationListResponse.java
@@ -1,0 +1,12 @@
+package com.marimo.server.domain.product.dto;
+
+import java.util.List;
+
+public record InvitationListResponse(
+        List<InvitationResponse> invitationList
+) {
+
+    public static InvitationListResponse of(final List<InvitationResponse> invitationList) {
+        return new InvitationListResponse(invitationList);
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/dto/InvitationResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/InvitationResponse.java
@@ -1,0 +1,24 @@
+package com.marimo.server.domain.product.dto;
+
+public record InvitationResponse(
+        Long id,
+        String imageUrl,
+        Boolean hasBundle,
+        String name,
+        Integer discountRate,
+        Integer price,
+        String quantity
+) {
+
+    public static InvitationResponse of(
+            final Long id,
+            final String imageUrl,
+            final Boolean hasBundle,
+            final String name,
+            final Integer discountRate,
+            final Integer price,
+            final String quantity
+    ) {
+        return new InvitationResponse(id, imageUrl, hasBundle, name, discountRate, price, quantity);
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/entity/InvitationEntity.java
+++ b/src/main/java/com/marimo/server/domain/product/entity/InvitationEntity.java
@@ -1,0 +1,51 @@
+package com.marimo.server.domain.product.entity;
+
+import com.marimo.server.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "invitation")
+public class InvitationEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "has_bundle", nullable = false)
+    private Boolean hasBundle;
+
+    @Column(name = "name", length = 50, nullable = false)
+    private String name;
+
+    @Column(name = "discount_rate", nullable = false)
+    private Integer discountRate;
+
+    @Column(name = "description", length = 100, nullable = false)
+    private String description;
+
+    @Builder
+    public InvitationEntity(
+            Long id,
+            Boolean hasBundle,
+            String name,
+            Integer discountRate,
+            String description
+    ) {
+        this.id = id;
+        this.hasBundle = hasBundle;
+        this.name = name;
+        this.discountRate = discountRate;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/entity/InvitationOptionEntity.java
+++ b/src/main/java/com/marimo/server/domain/product/entity/InvitationOptionEntity.java
@@ -1,0 +1,64 @@
+package com.marimo.server.domain.product.entity;
+
+import com.marimo.server.domain.product.enums.OptionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "invitation_option")
+public class InvitationOptionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "invitation_id", nullable = false)
+    private Long invitationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "option_type", length = 20, nullable = false)
+    private OptionType optionType;
+
+    @Column(name = "required", nullable = false)
+    private Boolean required;
+
+    @Column(name = "name", length = 20, nullable = false)
+    private String name;
+
+    @Column(name = "option_detail", length = 30, nullable = false)
+    private String optionDetail;
+
+    @Column(name = "price", nullable = false)
+    private Integer price;
+
+    @Builder
+    public InvitationOptionEntity(
+            Long id,
+            Long invitationId,
+            OptionType optionType,
+            Boolean required,
+            String name,
+            String optionDetail,
+            Integer price
+    ) {
+        this.id = id;
+        this.invitationId = invitationId;
+        this.optionType = optionType;
+        this.required = required;
+        this.name = name;
+        this.optionDetail = optionDetail;
+        this.price = price;
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/entity/ProductImageEntity.java
+++ b/src/main/java/com/marimo/server/domain/product/entity/ProductImageEntity.java
@@ -1,0 +1,49 @@
+package com.marimo.server.domain.product.entity;
+
+import com.marimo.server.domain.product.enums.ImageType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "product_image")
+public class ProductImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "image_type", length = 30, nullable = false)
+    private ImageType imageType;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "image_url", columnDefinition = "text", nullable = false)
+    private String imageUrl;
+
+    @Builder
+    public ProductImageEntity(
+            Long id,
+            ImageType imageType,
+            Long productId,
+            String imageUrl
+    ) {
+        this.id = id;
+        this.imageType = imageType;
+        this.productId = productId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/enums/ImageType.java
+++ b/src/main/java/com/marimo/server/domain/product/enums/ImageType.java
@@ -2,7 +2,10 @@ package com.marimo.server.domain.product.enums;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ImageType {
 
     INVITATION,

--- a/src/main/java/com/marimo/server/domain/product/enums/ImageType.java
+++ b/src/main/java/com/marimo/server/domain/product/enums/ImageType.java
@@ -1,0 +1,31 @@
+package com.marimo.server.domain.product.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ImageType {
+
+    INVITATION,
+    PREVIDEO,
+    INVITATION_DETAIL,
+    PREVIDEO_DETAIL,
+    ;
+
+    private static final Map<String, ImageType> IMAGE_TYPE_MAP = new HashMap<>();
+
+    static {
+        for (ImageType imageType : ImageType.values()) {
+            IMAGE_TYPE_MAP.put(imageType.name(), imageType);
+        }
+    }
+
+    public static ImageType fromValue(String value) {
+        ImageType imageType = IMAGE_TYPE_MAP.get(value.toUpperCase());
+
+        if (imageType == null) {
+            throw new IllegalArgumentException("Invalid ImageType: " + value);
+        }
+
+        return imageType;
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/enums/OptionType.java
+++ b/src/main/java/com/marimo/server/domain/product/enums/OptionType.java
@@ -2,7 +2,10 @@ package com.marimo.server.domain.product.enums;
 
 import java.util.HashMap;
 import java.util.Map;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum OptionType {
 
     QUANTITY,

--- a/src/main/java/com/marimo/server/domain/product/enums/OptionType.java
+++ b/src/main/java/com/marimo/server/domain/product/enums/OptionType.java
@@ -1,0 +1,33 @@
+package com.marimo.server.domain.product.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum OptionType {
+
+    QUANTITY,
+    STICKER,
+    ENVELOPE,
+    RIBBON,
+    ADDITIONAL,
+    MOBILE,
+    ;
+
+    private static final Map<String, OptionType> OPTION_TYPE_MAP = new HashMap<>();
+
+    static {
+        for (OptionType optionType : OptionType.values()) {
+            OPTION_TYPE_MAP.put(optionType.name(), optionType);
+        }
+    }
+
+    public static OptionType fromValue(String value) {
+        OptionType optionType = OPTION_TYPE_MAP.get(value.toUpperCase());
+
+        if (optionType == null) {
+            throw new IllegalArgumentException("Invalid OptionType: " + value);
+        }
+
+        return optionType;
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/repository/BannerRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/BannerRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BannerRepository extends JpaRepository<BannerEntity, Long> {
 
-    List<BannerEntity> findAllByProductTypeAndActiveTrueOrderById(final ProductType productType);
+    List<BannerEntity> findAllByProductTypeAndActiveTrueOrderByIdDesc(final ProductType productType);
 }

--- a/src/main/java/com/marimo/server/domain/product/repository/InvitationOptionRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/InvitationOptionRepository.java
@@ -1,0 +1,11 @@
+package com.marimo.server.domain.product.repository;
+
+import com.marimo.server.domain.product.entity.InvitationOptionEntity;
+import com.marimo.server.domain.product.enums.OptionType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvitationOptionRepository extends JpaRepository<InvitationOptionEntity, Long> {
+
+    List<InvitationOptionEntity> findAllByOptionTypeOrderById(final OptionType optionType);
+}

--- a/src/main/java/com/marimo/server/domain/product/repository/InvitationRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/InvitationRepository.java
@@ -1,0 +1,10 @@
+package com.marimo.server.domain.product.repository;
+
+import com.marimo.server.domain.product.entity.InvitationEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvitationRepository extends JpaRepository<InvitationEntity, Long> {
+
+    List<InvitationEntity> findAllByOrderById();
+}

--- a/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductImageRepository extends JpaRepository<ProductImageEntity, Long> {
 
-    List<ProductImageEntity> findAllByImageTypeOrderByProductIdAscIdAsc(final ImageType imageType);
+    List<ProductImageEntity> findAllByImageTypeOrderById(final ImageType imageType);
 }

--- a/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
@@ -1,0 +1,11 @@
+package com.marimo.server.domain.product.repository;
+
+import com.marimo.server.domain.product.entity.ProductImageEntity;
+import com.marimo.server.domain.product.enums.ImageType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageRepository extends JpaRepository<ProductImageEntity, Long> {
+
+    List<ProductImageEntity> findAllByImageTypeOrderByProductIdAscIdAsc(final ImageType imageType);
+}

--- a/src/main/java/com/marimo/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/marimo/server/domain/product/service/ProductService.java
@@ -16,7 +16,6 @@ import com.marimo.server.domain.product.repository.InvitationRepository;
 import com.marimo.server.domain.product.repository.ProductImageRepository;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -66,13 +65,12 @@ public class ProductService {
                         ));
 
         List<InvitationResponse> invitationResponses = invitationRepository.findAllByOrderById().stream()
+                .filter(invitation ->
+                        invitationImageMap.containsKey(invitation.getId())
+                                && invitationOptionMap.containsKey(invitation.getId()))
                 .map(invitation -> {
                     String image = invitationImageMap.get(invitation.getId());
                     InvitationOptionEntity option = invitationOptionMap.get(invitation.getId());
-
-                    if (image == null || option == null) {
-                        return null;
-                    }
 
                     return InvitationResponse.of(
                             invitation.getId(),
@@ -84,7 +82,6 @@ public class ProductService {
                             option.getName()
                     );
                 })
-                .filter(Objects::nonNull)
                 .toList();
 
         return InvitationListResponse.of(invitationResponses);

--- a/src/main/java/com/marimo/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/marimo/server/domain/product/service/ProductService.java
@@ -2,9 +2,20 @@ package com.marimo.server.domain.product.service;
 
 import com.marimo.server.domain.product.dto.BannerListResponse;
 import com.marimo.server.domain.product.dto.BannerResponse;
+import com.marimo.server.domain.product.dto.InvitationListResponse;
+import com.marimo.server.domain.product.dto.InvitationResponse;
 import com.marimo.server.domain.product.entity.BannerEntity;
+import com.marimo.server.domain.product.entity.InvitationEntity;
+import com.marimo.server.domain.product.entity.InvitationOptionEntity;
+import com.marimo.server.domain.product.entity.ProductImageEntity;
+import com.marimo.server.domain.product.enums.ImageType;
+import com.marimo.server.domain.product.enums.OptionType;
 import com.marimo.server.domain.product.enums.ProductType;
 import com.marimo.server.domain.product.repository.BannerRepository;
+import com.marimo.server.domain.product.repository.InvitationOptionRepository;
+import com.marimo.server.domain.product.repository.InvitationRepository;
+import com.marimo.server.domain.product.repository.ProductImageRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +26,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProductService {
 
     private final BannerRepository bannerRepository;
+    private final InvitationRepository invitationRepository;
+    private final ProductImageRepository productImageRepository;
+    private final InvitationOptionRepository invitationOptionRepository;
 
     @Transactional(readOnly = true)
     public BannerListResponse fetchBanners(final ProductType productType) {
-        List<BannerEntity> bannerEntities =
-                bannerRepository.findAllByProductTypeAndActiveTrueOrderById(productType);
+        List<BannerEntity> bannerEntities = bannerRepository.findAllByProductTypeAndActiveTrueOrderByIdDesc(
+                productType);
 
         List<BannerResponse> bannerResponses = bannerEntities.stream()
                 .map(banner -> BannerResponse.of(
@@ -29,5 +43,45 @@ public class ProductService {
                 .toList();
 
         return BannerListResponse.of(bannerResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public InvitationListResponse fetchInvitations() {
+        List<InvitationEntity> invitationEntities = invitationRepository.findAllByOrderById();
+        List<ProductImageEntity> productImageEntities =
+                productImageRepository.findAllByImageTypeOrderByProductIdAscIdAsc(ImageType.INVITATION);
+        List<InvitationOptionEntity> invitationOptionEntities =
+                invitationOptionRepository.findAllByOptionTypeOrderById(OptionType.QUANTITY);
+        List<InvitationResponse> invitationResponses = new ArrayList<>();
+
+        for (InvitationEntity invitation : invitationEntities) {
+            ProductImageEntity productImage = productImageEntities.stream()
+                    .filter(image -> image.getProductId().equals(invitation.getId()))
+                    .findFirst()
+                    .orElse(null);
+
+            InvitationOptionEntity invitationOption = invitationOptionEntities.stream()
+                    .filter(option -> option.getInvitationId().equals(invitation.getId()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (productImage == null || invitationOption == null) {
+                continue;
+            }
+
+            invitationResponses.add(
+                    InvitationResponse.of(
+                            invitation.getId(),
+                            productImage.getImageUrl(),
+                            invitation.getHasBundle(),
+                            invitation.getName(),
+                            invitation.getDiscountRate(),
+                            invitationOption.getPrice(),
+                            invitationOption.getName()
+                    )
+            );
+        }
+
+        return InvitationListResponse.of(invitationResponses);
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #5 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 청첩장 상품 목록 조회 API를 구현했습니다.
- 스트림 필터를 반복 스캔하는 방식에서 Map 기반 컬렉션 매칭 방식으로 최적화했습니다.