### PR TITLE
[FEAT/#7] 청첩장 상세페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
+++ b/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
@@ -1,15 +1,19 @@
 package com.marimo.server.domain.product.controller;
 
 import com.marimo.server.domain.product.dto.BannerListResponse;
+import com.marimo.server.domain.product.dto.InvitationDetailResponse;
 import com.marimo.server.domain.product.dto.InvitationListResponse;
 import com.marimo.server.domain.product.enums.ProductType;
 import com.marimo.server.domain.product.service.ProductService;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,6 +42,17 @@ public class ProductController {
     public ResponseEntity<InvitationListResponse> getInvitations() {
         return ResponseEntity.ok(
                 productService.fetchInvitations()
+        );
+    }
+
+    @GetMapping(path = "/invitations/{invitationId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<InvitationDetailResponse> getInvitationDetail(
+            @NotNull(message = "invitationId는 필수입니다.")
+            @Positive(message = "invitationId는 양수여야 합니다.")
+            @PathVariable(name = "invitationId") final Long invitationId
+    ) {
+        return ResponseEntity.ok(
+                productService.fetchInvitationDetail(invitationId)
         );
     }
 }

--- a/src/main/java/com/marimo/server/domain/product/dto/InvitationDetailResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/InvitationDetailResponse.java
@@ -1,0 +1,34 @@
+package com.marimo.server.domain.product.dto;
+
+import java.util.List;
+
+public record InvitationDetailResponse(
+        String mainImageUrl,
+        String name,
+        Integer discountRate,
+        Integer price,
+        String description,
+        List<OptionGroupResponse> optionGroupList,
+        List<String> detailImageList
+) {
+
+    public static InvitationDetailResponse of(
+            final String mainImageUrl,
+            final String name,
+            final Integer discountRate,
+            final Integer price,
+            final String description,
+            final List<OptionGroupResponse> optionGroupList,
+            final List<String> detailImageList
+    ) {
+        return new InvitationDetailResponse(
+                mainImageUrl,
+                name,
+                discountRate,
+                price,
+                description,
+                optionGroupList,
+                detailImageList
+        );
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/dto/OptionGroupResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/OptionGroupResponse.java
@@ -1,0 +1,17 @@
+package com.marimo.server.domain.product.dto;
+
+import com.marimo.server.domain.product.enums.OptionType;
+import java.util.List;
+
+public record OptionGroupResponse(
+        OptionType optionType,
+        List<OptionResponse> optionList
+) {
+
+    public static OptionGroupResponse of(
+            final OptionType optionType,
+            final List<OptionResponse> optionList
+    ) {
+        return new OptionGroupResponse(optionType, optionList);
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/dto/OptionResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/OptionResponse.java
@@ -1,0 +1,22 @@
+package com.marimo.server.domain.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public record OptionResponse(
+        Long id,
+        String name,
+        String optionDetail,
+        Integer price
+) {
+
+    public static OptionResponse of(
+            final Long id,
+            final String name,
+            final String optionDetail,
+            final Integer price
+    ) {
+        return new OptionResponse(id, name, optionDetail, price);
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/repository/InvitationOptionRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/InvitationOptionRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface InvitationOptionRepository extends JpaRepository<InvitationOptionEntity, Long> {
 
     List<InvitationOptionEntity> findAllByOptionTypeOrderById(final OptionType optionType);
+
+    List<InvitationOptionEntity> findAllByInvitationIdOrderById(final Long invitationId);
 }

--- a/src/main/java/com/marimo/server/domain/product/repository/InvitationRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/InvitationRepository.java
@@ -1,10 +1,18 @@
 package com.marimo.server.domain.product.repository;
 
 import com.marimo.server.domain.product.entity.InvitationEntity;
+import com.marimo.server.global.exception.BusinessException;
+import com.marimo.server.global.exception.ErrorType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InvitationRepository extends JpaRepository<InvitationEntity, Long> {
 
     List<InvitationEntity> findAllByOrderById();
+
+    default InvitationEntity findByIdOrElseThrow(Long invitationId) {
+        return findById(invitationId).orElseThrow(
+                () -> new BusinessException(ErrorType.NOT_FOUND_INVITATION_ERROR)
+        );
+    }
 }

--- a/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ProductImageRepository extends JpaRepository<ProductImageEntity, Long> {
 
     List<ProductImageEntity> findAllByImageTypeOrderById(final ImageType imageType);
+
+    List<ProductImageEntity> findAllByProductIdOrderById(final Long productId);
 }

--- a/src/main/java/com/marimo/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/marimo/server/domain/product/service/ProductService.java
@@ -2,9 +2,13 @@ package com.marimo.server.domain.product.service;
 
 import com.marimo.server.domain.product.dto.BannerListResponse;
 import com.marimo.server.domain.product.dto.BannerResponse;
+import com.marimo.server.domain.product.dto.InvitationDetailResponse;
 import com.marimo.server.domain.product.dto.InvitationListResponse;
 import com.marimo.server.domain.product.dto.InvitationResponse;
+import com.marimo.server.domain.product.dto.OptionGroupResponse;
+import com.marimo.server.domain.product.dto.OptionResponse;
 import com.marimo.server.domain.product.entity.BannerEntity;
+import com.marimo.server.domain.product.entity.InvitationEntity;
 import com.marimo.server.domain.product.entity.InvitationOptionEntity;
 import com.marimo.server.domain.product.entity.ProductImageEntity;
 import com.marimo.server.domain.product.enums.ImageType;
@@ -14,6 +18,7 @@ import com.marimo.server.domain.product.repository.BannerRepository;
 import com.marimo.server.domain.product.repository.InvitationOptionRepository;
 import com.marimo.server.domain.product.repository.InvitationRepository;
 import com.marimo.server.domain.product.repository.ProductImageRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -87,5 +92,59 @@ public class ProductService {
                 .toList();
 
         return InvitationListResponse.of(invitationResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public InvitationDetailResponse fetchInvitationDetail(final Long invitationId) {
+        InvitationEntity invitationEntity = invitationRepository.findByIdOrElseThrow(invitationId);
+
+        List<ProductImageEntity> productImageEntities =
+                productImageRepository.findAllByProductIdOrderById(invitationId);
+
+        String mainImageUrl = productImageEntities.stream()
+                .filter(productImage -> productImage.getImageType() == ImageType.INVITATION)
+                .findFirst()
+                .map(ProductImageEntity::getImageUrl)
+                .orElse("https://avatars.githubusercontent.com/u/198884528?s=200&v=4"); // TODO: 기본 이미지 생기면 변경
+
+        List<String> detailImages = productImageEntities.stream()
+                .filter(productImage -> productImage.getImageType() == ImageType.INVITATION_DETAIL)
+                .map(ProductImageEntity::getImageUrl)
+                .toList();
+
+        Map<OptionType, List<OptionResponse>> optionListMap =
+                invitationOptionRepository.findAllByInvitationIdOrderById(invitationId).stream()
+                        .collect(Collectors.groupingBy(
+                                InvitationOptionEntity::getOptionType,
+                                Collectors.mapping(option -> OptionResponse.of(
+                                        option.getId(),
+                                        option.getName(),
+                                        option.getOptionDetail(),
+                                        option.getPrice()
+                                ), Collectors.toUnmodifiableList())
+                        ));
+
+        int price = optionListMap.getOrDefault(OptionType.QUANTITY, List.of()).stream()
+                .mapToInt(OptionResponse::price)
+                .min()
+                .orElse(0);
+
+        List<OptionGroupResponse> optionGroupResponses = Arrays.stream(OptionType.values())
+                .map(optionType -> OptionGroupResponse.of(
+                        optionType,
+                        optionListMap.getOrDefault(optionType, List.of())
+                ))
+                .filter(optionGroup -> !optionGroup.optionList().isEmpty())
+                .toList();
+
+        return InvitationDetailResponse.of(
+                mainImageUrl,
+                invitationEntity.getName(),
+                invitationEntity.getDiscountRate(),
+                price,
+                invitationEntity.getDescription(),
+                optionGroupResponses,
+                detailImages
+        );
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #7 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 청첩장 상세페이지 조회 API를 구현했습니다.