### PR TITLE
[FEAT/#11] 식전영상 상세페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
+++ b/src/main/java/com/marimo/server/domain/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.marimo.server.domain.product.controller;
 import com.marimo.server.domain.product.dto.BannerListResponse;
 import com.marimo.server.domain.product.dto.InvitationDetailResponse;
 import com.marimo.server.domain.product.dto.InvitationListResponse;
+import com.marimo.server.domain.product.dto.PreVideoDetailResponse;
 import com.marimo.server.domain.product.dto.PreVideoListResponse;
 import com.marimo.server.domain.product.enums.ProductType;
 import com.marimo.server.domain.product.service.ProductService;
@@ -61,6 +62,17 @@ public class ProductController {
     public ResponseEntity<PreVideoListResponse> getPreVideos() {
         return ResponseEntity.ok(
                 productService.fetchPreVideos()
+        );
+    }
+
+    @GetMapping(path = "/pre-videos/{preVideoId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<PreVideoDetailResponse> getPreVideoDetail(
+            @NotNull(message = "preVideoId는 필수입니다.")
+            @Positive(message = "preVideoId는 양수여야 합니다.")
+            @PathVariable(name = "preVideoId") final Long preVideoId
+    ) {
+        return ResponseEntity.ok(
+                productService.fetchPreVideoDetail(preVideoId)
         );
     }
 }

--- a/src/main/java/com/marimo/server/domain/product/dto/PreVideoDetailResponse.java
+++ b/src/main/java/com/marimo/server/domain/product/dto/PreVideoDetailResponse.java
@@ -1,0 +1,29 @@
+package com.marimo.server.domain.product.dto;
+
+public record PreVideoDetailResponse(
+        String mainImageUrl,
+        String name,
+        Integer discountRate,
+        Integer price,
+        String description,
+        String sampleVideoUrl
+) {
+
+    public static PreVideoDetailResponse of(
+            final String mainImageUrl,
+            final String name,
+            final Integer discountRate,
+            final Integer price,
+            final String description,
+            final String sampleVideoUrl
+    ) {
+        return new PreVideoDetailResponse(
+                mainImageUrl,
+                name,
+                discountRate,
+                price,
+                description,
+                sampleVideoUrl
+        );
+    }
+}

--- a/src/main/java/com/marimo/server/domain/product/repository/PreVideoRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/PreVideoRepository.java
@@ -1,10 +1,18 @@
 package com.marimo.server.domain.product.repository;
 
 import com.marimo.server.domain.product.entity.PreVideoEntity;
+import com.marimo.server.global.exception.BusinessException;
+import com.marimo.server.global.exception.ErrorType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PreVideoRepository extends JpaRepository<PreVideoEntity, Long> {
 
     List<PreVideoEntity> findAllByOrderById();
+
+    default PreVideoEntity findByIdOrElseThrow(Long preVideoId) {
+        return findById(preVideoId).orElseThrow(
+                () -> new BusinessException(ErrorType.NOT_FOUND_PRE_VIDEO_ERROR)
+        );
+    }
 }

--- a/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
+++ b/src/main/java/com/marimo/server/domain/product/repository/ProductImageRepository.java
@@ -3,11 +3,27 @@ package com.marimo.server.domain.product.repository;
 import com.marimo.server.domain.product.entity.ProductImageEntity;
 import com.marimo.server.domain.product.enums.ImageType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductImageRepository extends JpaRepository<ProductImageEntity, Long> {
 
     List<ProductImageEntity> findAllByImageTypeOrderById(final ImageType imageType);
 
     List<ProductImageEntity> findAllByProductIdOrderById(final Long productId);
+
+    @Query(value = """
+            SELECT p.image_url
+            FROM   product_image p
+            WHERE  p.image_type = :imageType
+              AND  p.product_id = :productId
+            ORDER BY p.id
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<String> findFirstImageUrlByImageTypeAndProductId(
+            @Param("imageType") String imageType,
+            @Param("productId") Long productId
+    );
 }

--- a/src/main/java/com/marimo/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/marimo/server/domain/product/service/ProductService.java
@@ -7,11 +7,13 @@ import com.marimo.server.domain.product.dto.InvitationListResponse;
 import com.marimo.server.domain.product.dto.InvitationResponse;
 import com.marimo.server.domain.product.dto.OptionGroupResponse;
 import com.marimo.server.domain.product.dto.OptionResponse;
+import com.marimo.server.domain.product.dto.PreVideoDetailResponse;
 import com.marimo.server.domain.product.dto.PreVideoListResponse;
 import com.marimo.server.domain.product.dto.PreVideoResponse;
 import com.marimo.server.domain.product.entity.BannerEntity;
 import com.marimo.server.domain.product.entity.InvitationEntity;
 import com.marimo.server.domain.product.entity.InvitationOptionEntity;
+import com.marimo.server.domain.product.entity.PreVideoEntity;
 import com.marimo.server.domain.product.entity.ProductImageEntity;
 import com.marimo.server.domain.product.enums.ImageType;
 import com.marimo.server.domain.product.enums.OptionType;
@@ -176,5 +178,26 @@ public class ProductService {
                 .toList();
 
         return PreVideoListResponse.of(preVideoResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public PreVideoDetailResponse fetchPreVideoDetail(final Long preVideoId) {
+        String mainImageUrl =
+                productImageRepository.findFirstImageUrlByImageTypeAndProductId(
+                                ImageType.PREVIDEO.name(),
+                                preVideoId
+                        )
+                        .orElse("https://avatars.githubusercontent.com/u/198884528?s=200&v=4"); // TODO: 기본 이미지 생기면 변경
+
+        PreVideoEntity preVideoEntity = preVideoRepository.findByIdOrElseThrow(preVideoId);
+
+        return PreVideoDetailResponse.of(
+                mainImageUrl,
+                preVideoEntity.getName(),
+                preVideoEntity.getDiscountRate(),
+                preVideoEntity.getPrice(),
+                preVideoEntity.getDescription(),
+                preVideoEntity.getSampleVideoUrl()
+        );
     }
 }


### PR DESCRIPTION
# 💡 Issue
- resolved: #11 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 식전영상 상세페이지 조회 API를 구현했습니다.
- 오름차순으로 정렬했을 때 첫번째 이미지를 메인 이미지로 설정했습니다.