### PR TITLE
[FEAT/#15] 모바일 청첩장 고유 주소 식별자 유효성 검증 API 구현

### DIFF
--- a/src/main/java/com/marimo/server/domain/order/controller/OrderController.java
+++ b/src/main/java/com/marimo/server/domain/order/controller/OrderController.java
@@ -4,23 +4,40 @@ import com.marimo.server.domain.order.dto.InvitationOrderRequest;
 import com.marimo.server.domain.order.dto.OrderResponse;
 import com.marimo.server.domain.order.service.OrderService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/orders")
+@RequestMapping("/api")
+@Validated
 public class OrderController {
 
     private final OrderService orderService;
 
+    @GetMapping(path = "/mobile-invitations/validate")
+    public ResponseEntity<Void> getUrlSlugValidation(
+            @NotBlank(message = "urlSlug는 공백일 수 없습니다.")
+            @Pattern(regexp = "^[a-z0-9]{3,15}$", message = "urlSlug는 영문 소문자와 숫자만 사용할 수 있으며 3~15자 사이여야 합니다.")
+            @RequestParam final String urlSlug
+    ) {
+        orderService.validateUrlSlug(urlSlug);
+
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping(
-            path = "/invitations",
+            path = "/orders/invitations",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )

--- a/src/main/java/com/marimo/server/domain/order/dto/MobileInvitationInfo.java
+++ b/src/main/java/com/marimo/server/domain/order/dto/MobileInvitationInfo.java
@@ -5,9 +5,9 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record MobileInvitationInfo(
-        @NotBlank(message = "urlPath은 공백일 수 없습니다.")
-        @Pattern(regexp = "^[a-z0-9]{3,15}$", message = "urlPath는 영문 소문자와 숫자만 사용할 수 있으며 3~15자 사이여야 합니다.")
-        String urlPath,
+        @NotBlank(message = "urlSlug는 공백일 수 없습니다.")
+        @Pattern(regexp = "^[a-z0-9]{3,15}$", message = "urlSlug는 영문 소문자와 숫자만 사용할 수 있으며 3~15자 사이여야 합니다.")
+        String urlSlug,
 
         @NotBlank(message = "mainImage는 공백일 수 없습니다.")
         String mainImage,

--- a/src/main/java/com/marimo/server/domain/order/entity/InvitationOrderEntity.java
+++ b/src/main/java/com/marimo/server/domain/order/entity/InvitationOrderEntity.java
@@ -113,8 +113,8 @@ public class InvitationOrderEntity extends BaseTimeEntity {
     @Column(name = "has_mobile_invitation", nullable = false)
     private Boolean hasMobileInvitation;
 
-    @Column(name = "mobile_invitation_url", length = 20)
-    private String mobileInvitationUrl;
+    @Column(name = "mobile_invitation_url_slug", length = 20)
+    private String mobileInvitationUrlSlug;
 
     @Column(name = "mobile_invitation_message", length = 200)
     private String mobileInvitationMessage;
@@ -209,7 +209,7 @@ public class InvitationOrderEntity extends BaseTimeEntity {
             String receptionAddress,
             LocalDateTime receptionDatetime,
             Boolean hasMobileInvitation,
-            String mobileInvitationUrl,
+            String mobileInvitationUrlSlug,
             String mobileInvitationMessage,
             Boolean hasGallery,
             Boolean hasContactOption,
@@ -260,7 +260,7 @@ public class InvitationOrderEntity extends BaseTimeEntity {
         this.receptionAddress = receptionAddress;
         this.receptionDatetime = receptionDatetime;
         this.hasMobileInvitation = hasMobileInvitation;
-        this.mobileInvitationUrl = mobileInvitationUrl;
+        this.mobileInvitationUrlSlug = mobileInvitationUrlSlug;
         this.mobileInvitationMessage = mobileInvitationMessage;
         this.hasGallery = hasGallery;
         this.hasContactOption = hasContactOption;

--- a/src/main/java/com/marimo/server/domain/order/repository/InvitationOrderRepository.java
+++ b/src/main/java/com/marimo/server/domain/order/repository/InvitationOrderRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InvitationOrderRepository extends JpaRepository<InvitationOrderEntity, Long> {
 
+    boolean existsByMobileInvitationUrlSlug(String mobileInvitationUrlSlug);
 }

--- a/src/main/java/com/marimo/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/marimo/server/domain/order/service/OrderService.java
@@ -58,6 +58,13 @@ public class OrderService {
     private final OrderAttachmentRepository orderAttachmentRepository;
     private final OrderRepository orderRepository;
 
+    @Transactional(readOnly = true)
+    public void validateUrlSlug(final String urlSlug) {
+        if (invitationOrderRepository.existsByMobileInvitationUrlSlug(urlSlug)) {
+            throw new BusinessException(ErrorType.DUPLICATE_URL_SLUG_ERROR);
+        }
+    }
+
     @Transactional
     public OrderResponse createInvitationOrder(final InvitationOrderRequest request) {
         if (!invitationRepository.existsById(request.invitationId())) {

--- a/src/main/java/com/marimo/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/marimo/server/domain/order/service/OrderService.java
@@ -67,9 +67,19 @@ public class OrderService {
 
     @Transactional
     public OrderResponse createInvitationOrder(final InvitationOrderRequest request) {
-        if (!invitationRepository.existsById(request.invitationId())) {
+        long invitationId = request.invitationId();
+
+        if (!invitationRepository.existsById(invitationId)) {
             throw new BusinessException(ErrorType.NOT_FOUND_INVITATION_ERROR);
         }
+
+        boolean hasMobileInvitation = request.hasMobileInvitation();
+
+        if (hasMobileInvitation) {
+            validateUrlSlug(request.mobileInvitationInfo().urlSlug());
+        }
+
+        validateSelectedOptions(invitationId, request.optionList());
 
         CustomerInfo customerInfo = request.customerInfo();
         InvitationCommonInfo invitationCommonInfo = request.invitationCommonInfo();
@@ -81,7 +91,6 @@ public class OrderService {
         boolean hasReception = request.hasReception();
         Reception reception = hasReception ? request.reception() : null;
 
-        boolean hasMobileInvitation = request.hasMobileInvitation();
         MobileInvitationInfo mobileInvitationInfo = hasMobileInvitation ? request.mobileInvitationInfo() : null;
 
         Boolean hasGallery = request.hasGallery();
@@ -107,7 +116,7 @@ public class OrderService {
 
         OrderEntity orderEntity = OrderEntity.builder()
                 .productType(ProductType.INVITATION)
-                .productId(request.invitationId())
+                .productId(invitationId)
                 .code(generateUniqueOrderCode())
                 .customerName(customerInfo.name())
                 .zoneCode(customerInfo.zoneCode())
@@ -129,7 +138,6 @@ public class OrderService {
         OrderEntity savedOrder = orderRepository.save(orderEntity);
 
         Long orderId = savedOrder.getId();
-        validateSelectedOptions(savedOrder.getProductId(), request.optionList());
 
         InvitationOrderEntity invitationOrderEntity = InvitationOrderEntity.builder()
                 .orderId(orderId)

--- a/src/main/java/com/marimo/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/marimo/server/domain/order/service/OrderService.java
@@ -59,7 +59,7 @@ public class OrderService {
     private final OrderRepository orderRepository;
 
     @Transactional
-    public OrderResponse createInvitationOrder(InvitationOrderRequest request) {
+    public OrderResponse createInvitationOrder(final InvitationOrderRequest request) {
         if (!invitationRepository.existsById(request.invitationId())) {
             throw new BusinessException(ErrorType.NOT_FOUND_INVITATION_ERROR);
         }
@@ -334,8 +334,8 @@ public class OrderService {
     }
 
     private void validateSelectedOptions(
-            Long invitationId,
-            List<SelectedOption> selectedOptions
+            final Long invitationId,
+            final List<SelectedOption> selectedOptions
     ) {
         Set<Long> optionIdSet = new HashSet<>();
 
@@ -372,7 +372,7 @@ public class OrderService {
         }
     }
 
-    private FileType extractFileTypeFromUrl(String fileUrl) {
+    private FileType extractFileTypeFromUrl(final String fileUrl) {
         if (!fileUrl.contains(".")) {
             throw new BusinessException(ErrorType.INVALID_FILE_TYPE_ERROR);
         }

--- a/src/main/java/com/marimo/server/domain/order/service/OrderService.java
+++ b/src/main/java/com/marimo/server/domain/order/service/OrderService.java
@@ -203,7 +203,7 @@ public class OrderService {
 
                 // 모바일 청첩장
                 .hasMobileInvitation(hasMobileInvitation)
-                .mobileInvitationUrl(mobileInvitationInfo != null ? mobileInvitationInfo.urlPath() : null)
+                .mobileInvitationUrlSlug(mobileInvitationInfo != null ? mobileInvitationInfo.urlSlug() : null)
                 .mobileInvitationMessage(mobileInvitationInfo != null ? mobileInvitationInfo.message() : null)
 
                 // 갤러리

--- a/src/main/java/com/marimo/server/domain/product/service/ProductService.java
+++ b/src/main/java/com/marimo/server/domain/product/service/ProductService.java
@@ -94,7 +94,7 @@ public class ProductService {
         return InvitationListResponse.of(invitationResponses);
     }
 
-    private Map<Long, String> findImageMapByImageType(ImageType imageType) {
+    private Map<Long, String> findImageMapByImageType(final ImageType imageType) {
         return productImageRepository.findAllByImageTypeOrderById(imageType).stream()
                 .collect(Collectors.toMap(
                         ProductImageEntity::getProductId,

--- a/src/main/java/com/marimo/server/global/exception/ErrorType.java
+++ b/src/main/java/com/marimo/server/global/exception/ErrorType.java
@@ -36,6 +36,9 @@ public enum ErrorType {
     NOT_FOUND_INVITATION_ERROR(HttpStatus.NOT_FOUND, 40403, "존재하지 않는 청첩장 id입니다."),
     NOT_FOUND_PRE_VIDEO_ERROR(HttpStatus.NOT_FOUND, 40404, "존재하지 않는 식전영상 id입니다."),
 
+    /* 409 Conflict */
+    DUPLICATE_URL_SLUG_ERROR(HttpStatus.CONFLICT, 40901, "이미 사용 중인 고유 주소 식별자입니다."),
+
     /* 500 Internal Server Error */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "예상치 못한 서버 에러가 발생했습니다."),
     FAILED_GET_PRESIGNED_URL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50002, "Presigned URL 획득에 실패했습니다."),


### PR DESCRIPTION
# 💡 Issue
- resolved: #15 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 모바일 청첩장 고유 주소 식별자 유효성 검증 API를 구현했습니다.
- 청첩장 주문하기 API 호출 시에도 본 식별자 유효성 검증을 진행하도록 수정했습니다.