### PR TITLE
[FEAT/#21] 서킷 브레이커 + fallback 기반 장애 대응 및 주문 알림 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,18 @@ dependencies {
 
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.32.9'
+
+    // JSON 처리를 위한 Jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    
+    // OkHttp for Discord webhook
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    
+    // Caffeine Cache for duplicate log prevention
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    
+    // JetBrains Annotations
+    implementation 'org.jetbrains:annotations:24.0.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/marimo/server/ServerApplication.java
+++ b/src/main/java/com/marimo/server/ServerApplication.java
@@ -2,12 +2,14 @@ package com.marimo.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ServerApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/marimo/server/domain/order/controller/OrderController.java
+++ b/src/main/java/com/marimo/server/domain/order/controller/OrderController.java
@@ -7,10 +7,13 @@ import com.marimo.server.domain.order.dto.response.OrderResponse;
 import com.marimo.server.domain.order.dto.response.PresignedUrlListResponse;
 import com.marimo.server.domain.order.enums.AttachmentType;
 import com.marimo.server.domain.order.service.OrderService;
+import com.marimo.server.global.event.InvitationOrderCreatedEvent;
+import com.marimo.server.global.event.PreVideoOrderCreatedEvent;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -28,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
     private final OrderService orderService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @GetMapping(path = "/mobile-invitations/validate")
     public ResponseEntity<Void> getUrlSlugValidation(
@@ -48,9 +52,12 @@ public class OrderController {
     public ResponseEntity<OrderResponse> createInvitationOrder(
             @Valid @RequestBody final InvitationOrderRequest request
     ) {
-        return ResponseEntity.ok(
-                orderService.createInvitationOrder(request)
-        );
+        OrderResponse orderResponse = orderService.createInvitationOrder(request);
+
+        // 🎯 이벤트 발행 (비동기 처리)
+        eventPublisher.publishEvent(new InvitationOrderCreatedEvent(request, orderResponse));
+
+        return ResponseEntity.ok(orderResponse);
     }
 
     @PostMapping(
@@ -61,9 +68,12 @@ public class OrderController {
     public ResponseEntity<OrderResponse> createPreVideoOrder(
             @Valid @RequestBody final PreVideoOrderRequest request
     ) {
-        return ResponseEntity.ok(
-                orderService.createPreVideoOrder(request)
-        );
+        OrderResponse orderResponse = orderService.createPreVideoOrder(request);
+
+        // 🎯 이벤트 발행 (비동기 처리)
+        eventPublisher.publishEvent(new PreVideoOrderCreatedEvent(request, orderResponse));
+
+        return ResponseEntity.ok(orderResponse);
     }
 
     @PostMapping(

--- a/src/main/java/com/marimo/server/global/adapter/S3Adapter.java
+++ b/src/main/java/com/marimo/server/global/adapter/S3Adapter.java
@@ -20,23 +20,31 @@ public class S3Adapter {
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
 
-    public String issuePresignedUrl(String s3Key, FileType fileType) {
-        return issuePresignedUrl(s3Key, fileType.getMimeType(), Duration.ofMinutes(15));
+    public String issuePresignedUrl(final String s3Key, final FileType fileType) {
+        return issuePresignedUrl(
+                s3Key,
+                fileType.getMimeType(),
+                Duration.ofMinutes(15)
+        );
     }
 
-    public String issuePresignedUrl(String s3Key, String contentType, Duration ttl) {
-        PutObjectRequest por = PutObjectRequest.builder()
+    public String issuePresignedUrl(
+            final String s3Key,
+            final String contentType,
+            final Duration ttl
+    ) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(s3Key)
                 .contentType(contentType)
                 .build();
 
-        PresignedPutObjectRequest pre = s3Presigner.presignPutObject(
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(
                 b -> b
-                        .putObjectRequest(por)
+                        .putObjectRequest(putObjectRequest)
                         .signatureDuration(ttl)
         );
 
-        return pre.url().toString();
+        return presignedPutObjectRequest.url().toString();
     }
 }

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerConfig.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerConfig.java
@@ -1,21 +1,12 @@
 package com.marimo.server.global.circuitbreaker;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@Getter
-@Setter
-public class CircuitBreakerConfig {
+@ConfigurationProperties(prefix = "circuit-breaker")
+public record CircuitBreakerConfig(
+        int failureThreshold,
+        int successThreshold,
+        long timeoutDuration
+) {
 
-    // 실패 횟수 임계값 (이 횟수만큼 실패하면 OPEN 상태로 전환)
-    private int failureThreshold = 5;
-
-    // 성공 횟수 임계값 (HALF_OPEN 상태에서 이 횟수만큼 성공하면 CLOSED로 전환)
-    private int successThreshold = 3;
-
-    // OPEN 상태 유지 시간 (밀리초, 이 시간 후 HALF_OPEN으로 전환)
-    private long timeoutDuration = 60000; // 1분
-
-    // 통계 수집을 위한 시간 윈도우 (밀리초)
-    private long statisticsWindowDuration = 300000; // 5분
 }

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerConfig.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerConfig.java
@@ -1,0 +1,21 @@
+package com.marimo.server.global.circuitbreaker;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CircuitBreakerConfig {
+
+    // 실패 횟수 임계값 (이 횟수만큼 실패하면 OPEN 상태로 전환)
+    private int failureThreshold = 5;
+
+    // 성공 횟수 임계값 (HALF_OPEN 상태에서 이 횟수만큼 성공하면 CLOSED로 전환)
+    private int successThreshold = 3;
+
+    // OPEN 상태 유지 시간 (밀리초, 이 시간 후 HALF_OPEN으로 전환)
+    private long timeoutDuration = 60000; // 1분
+
+    // 통계 수집을 위한 시간 윈도우 (밀리초)
+    private long statisticsWindowDuration = 300000; // 5분
+}

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerMetrics.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerMetrics.java
@@ -1,0 +1,55 @@
+package com.marimo.server.global.circuitbreaker;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Getter;
+
+@Getter
+public class CircuitBreakerMetrics {
+
+    private final AtomicLong totalCalls = new AtomicLong(0);
+    private final AtomicLong failedCalls = new AtomicLong(0);
+    private final AtomicLong successfulCalls = new AtomicLong(0);
+    private final AtomicLong consecutiveFailures = new AtomicLong(0);
+    private final AtomicLong consecutiveSuccesses = new AtomicLong(0);
+
+    private volatile Instant lastFailureTime;
+    private volatile Instant lastSuccessTime;
+    private volatile Instant lastStateChangeTime = Instant.now();
+
+    public void recordSuccess() {
+        totalCalls.incrementAndGet();
+        successfulCalls.incrementAndGet();
+        consecutiveSuccesses.incrementAndGet();
+        consecutiveFailures.set(0);
+        lastSuccessTime = Instant.now();
+    }
+
+    public void recordFailure() {
+        totalCalls.incrementAndGet();
+        failedCalls.incrementAndGet();
+        consecutiveFailures.incrementAndGet();
+        consecutiveSuccesses.set(0);
+        lastFailureTime = Instant.now();
+    }
+
+    public void recordStateChange() {
+        lastStateChangeTime = Instant.now();
+    }
+
+    public double getFailureRate() {
+        long total = totalCalls.get();
+        if (total == 0) {
+            return 0.0;
+        }
+        return (double) failedCalls.get() / total;
+    }
+
+    public void reset() {
+        totalCalls.set(0);
+        failedCalls.set(0);
+        successfulCalls.set(0);
+        consecutiveFailures.set(0);
+        consecutiveSuccesses.set(0);
+    }
+}

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerMetrics.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerMetrics.java
@@ -1,55 +1,53 @@
 package com.marimo.server.global.circuitbreaker;
 
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 
 @Getter
 public class CircuitBreakerMetrics {
 
-    private final AtomicLong totalCalls = new AtomicLong(0);
-    private final AtomicLong failedCalls = new AtomicLong(0);
-    private final AtomicLong successfulCalls = new AtomicLong(0);
-    private final AtomicLong consecutiveFailures = new AtomicLong(0);
-    private final AtomicLong consecutiveSuccesses = new AtomicLong(0);
+    private long totalCallCount;
+    private long failureCallCount;
+    private long successCallCount;
+    private long failureStreak;
+    private long successStreak;
 
-    private volatile Instant lastFailureTime;
-    private volatile Instant lastSuccessTime;
-    private volatile Instant lastStateChangeTime = Instant.now();
+    private long lastFailureAtMillis;
+    private long lastSuccessAtMillis;
+    private long lastStateChangeTimeMillis = System.currentTimeMillis();
 
     public void recordSuccess() {
-        totalCalls.incrementAndGet();
-        successfulCalls.incrementAndGet();
-        consecutiveSuccesses.incrementAndGet();
-        consecutiveFailures.set(0);
-        lastSuccessTime = Instant.now();
+        totalCallCount++;
+        successCallCount++;
+        successStreak++;
+        failureStreak = 0;
+        lastSuccessAtMillis = System.currentTimeMillis();
     }
 
     public void recordFailure() {
-        totalCalls.incrementAndGet();
-        failedCalls.incrementAndGet();
-        consecutiveFailures.incrementAndGet();
-        consecutiveSuccesses.set(0);
-        lastFailureTime = Instant.now();
+        totalCallCount++;
+        failureCallCount++;
+        failureStreak++;
+        successStreak = 0;
+        lastFailureAtMillis = System.currentTimeMillis();
     }
 
     public void recordStateChange() {
-        lastStateChangeTime = Instant.now();
+        lastStateChangeTimeMillis = System.currentTimeMillis();
     }
 
-    public double getFailureRate() {
-        long total = totalCalls.get();
-        if (total == 0) {
-            return 0.0;
-        }
-        return (double) failedCalls.get() / total;
+    public double failureRatio() {
+        return (totalCallCount == 0) ? 0.0 : (double) failureCallCount / totalCallCount;
+    }
+
+    public double failureRatePercent() {
+        return failureRatio() * 100.0;
     }
 
     public void reset() {
-        totalCalls.set(0);
-        failedCalls.set(0);
-        successfulCalls.set(0);
-        consecutiveFailures.set(0);
-        consecutiveSuccesses.set(0);
+        totalCallCount = 0;
+        failureCallCount = 0;
+        successCallCount = 0;
+        failureStreak = 0;
+        successStreak = 0;
     }
 }

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerState.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerState.java
@@ -1,7 +1,7 @@
 package com.marimo.server.global.circuitbreaker;
 
 public enum CircuitBreakerState {
-    CLOSED,    // 정상 상태 - Primary (Slack) 사용
-    OPEN,      // 장애 상태 - Fallback (Discord)으로 우회
-    HALF_OPEN  // 회복 테스트 상태 - Primary 재시도 중
+    CLOSED,
+    OPEN,
+    HALF_OPEN
 }

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerState.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerState.java
@@ -1,0 +1,7 @@
+package com.marimo.server.global.circuitbreaker;
+
+public enum CircuitBreakerState {
+    CLOSED,    // 정상 상태 - Primary (Slack) 사용
+    OPEN,      // 장애 상태 - Fallback (Discord)으로 우회
+    HALF_OPEN  // 회복 테스트 상태 - Primary 재시도 중
+}

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerStatus.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerStatus.java
@@ -1,0 +1,33 @@
+package com.marimo.server.global.circuitbreaker;
+
+import java.time.Instant;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CircuitBreakerStatus {
+
+    private final CircuitBreakerState state;
+    private final long totalCalls;
+    private final long failedCalls;
+    private final long successfulCalls;
+    private final long consecutiveFailures;
+    private final long consecutiveSuccesses;
+    private final double failureRate;
+    private final Instant lastFailureTime;
+    private final Instant lastSuccessTime;
+    private final Instant lastStateChangeTime;
+
+    public String getStateDescription() {
+        return switch (state) {
+            case CLOSED -> "🟢 정상 - Slack 알림 활성화";
+            case OPEN -> "🔴 장애 - Discord 폴백 모드";
+            case HALF_OPEN -> "🟡 회복 테스트 - Slack 재시도 중";
+        };
+    }
+
+    public boolean isUsingFallback() {
+        return state == CircuitBreakerState.OPEN;
+    }
+}

--- a/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerStatus.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/CircuitBreakerStatus.java
@@ -1,6 +1,5 @@
 package com.marimo.server.global.circuitbreaker;
 
-import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,15 +8,7 @@ import lombok.Getter;
 public class CircuitBreakerStatus {
 
     private final CircuitBreakerState state;
-    private final long totalCalls;
-    private final long failedCalls;
-    private final long successfulCalls;
-    private final long consecutiveFailures;
-    private final long consecutiveSuccesses;
-    private final double failureRate;
-    private final Instant lastFailureTime;
-    private final Instant lastSuccessTime;
-    private final Instant lastStateChangeTime;
+    private final CircuitBreakerMetrics metrics;
 
     public String getStateDescription() {
         return switch (state) {

--- a/src/main/java/com/marimo/server/global/circuitbreaker/SlackCircuitBreaker.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/SlackCircuitBreaker.java
@@ -1,0 +1,163 @@
+package com.marimo.server.global.circuitbreaker;
+
+import java.time.Instant;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SlackCircuitBreaker {
+
+    private final CircuitBreakerConfig config;
+    private final CircuitBreakerMetrics metrics;
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private volatile CircuitBreakerState state = CircuitBreakerState.CLOSED;
+    private volatile Instant lastOpenTime;
+
+    public SlackCircuitBreaker(CircuitBreakerConfig config) {
+        this.config = config;
+        this.metrics = new CircuitBreakerMetrics();
+    }
+
+    /**
+     * Slack 알림 시도 전 Circuit Breaker 상태 확인
+     *
+     * @return true if should use Slack (primary), false if should use Discord (fallback)
+     */
+    public boolean canExecute() {
+        lock.readLock().lock();
+        try {
+            CircuitBreakerState currentState = getCurrentState();
+
+            switch (currentState) {
+                case CLOSED:
+                    return true; // Slack 사용 가능
+                case OPEN:
+                    return false; // Discord로 fallback
+                case HALF_OPEN:
+                    // HALF_OPEN 상태에서는 제한적으로 Slack 시도
+                    return true;
+                default:
+                    return false;
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Slack 알림 성공 시 호출
+     */
+    public void recordSuccess() {
+        lock.writeLock().lock();
+        try {
+            metrics.recordSuccess();
+
+            CircuitBreakerState currentState = getCurrentState();
+
+            if (currentState == CircuitBreakerState.HALF_OPEN) {
+                // HALF_OPEN 상태에서 연속 성공이 임계값에 도달하면 CLOSED로 전환
+                if (metrics.getConsecutiveSuccesses().get() >= config.getSuccessThreshold()) {
+                    transitionTo(CircuitBreakerState.CLOSED);
+                    log.info("🟢 Slack Circuit Breaker: HALF_OPEN → CLOSED (연속 성공 {}회)",
+                            metrics.getConsecutiveSuccesses().get());
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Slack 알림 실패 시 호출
+     */
+    public void recordFailure() {
+        lock.writeLock().lock();
+        try {
+            metrics.recordFailure();
+
+            CircuitBreakerState currentState = getCurrentState();
+
+            if (currentState == CircuitBreakerState.CLOSED || currentState == CircuitBreakerState.HALF_OPEN) {
+                // 연속 실패가 임계값에 도달하면 OPEN으로 전환
+                if (metrics.getConsecutiveFailures().get() >= config.getFailureThreshold()) {
+                    transitionTo(CircuitBreakerState.OPEN);
+                    log.warn("🔴 Slack Circuit Breaker: {} → OPEN (연속 실패 {}회), Discord로 fallback 시작",
+                            currentState, metrics.getConsecutiveFailures().get());
+                    lastOpenTime = Instant.now();
+                }
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * 현재 상태를 반환 (시간 기반 상태 전환 포함)
+     */
+    private CircuitBreakerState getCurrentState() {
+        if (state == CircuitBreakerState.OPEN && lastOpenTime != null) {
+            long timeSinceOpened = Instant.now().toEpochMilli() - lastOpenTime.toEpochMilli();
+
+            if (timeSinceOpened >= config.getTimeoutDuration()) {
+                transitionTo(CircuitBreakerState.HALF_OPEN);
+                log.info("🟡 Slack Circuit Breaker: OPEN → HALF_OPEN (타임아웃 {}ms 경과)",
+                        config.getTimeoutDuration());
+            }
+        }
+
+        return state;
+    }
+
+    private void transitionTo(CircuitBreakerState newState) {
+        CircuitBreakerState oldState = this.state;
+        this.state = newState;
+        metrics.recordStateChange();
+
+        if (newState == CircuitBreakerState.CLOSED) {
+            metrics.reset(); // CLOSED로 전환 시 메트릭 리셋
+        }
+
+        if (oldState != newState) {
+            log.info("Circuit Breaker 상태 변경: {} → {}", oldState, newState);
+        }
+    }
+
+    /**
+     * Circuit Breaker 상태 정보 조회
+     */
+    public CircuitBreakerStatus getStatus() {
+        lock.readLock().lock();
+        try {
+            return CircuitBreakerStatus.builder()
+                    .state(getCurrentState())
+                    .totalCalls(metrics.getTotalCalls().get())
+                    .failedCalls(metrics.getFailedCalls().get())
+                    .successfulCalls(metrics.getSuccessfulCalls().get())
+                    .consecutiveFailures(metrics.getConsecutiveFailures().get())
+                    .consecutiveSuccesses(metrics.getConsecutiveSuccesses().get())
+                    .failureRate(metrics.getFailureRate())
+                    .lastFailureTime(metrics.getLastFailureTime())
+                    .lastSuccessTime(metrics.getLastSuccessTime())
+                    .lastStateChangeTime(metrics.getLastStateChangeTime())
+                    .build();
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Circuit Breaker 강제 리셋 (관리용)
+     */
+    public void reset() {
+        lock.writeLock().lock();
+        try {
+            transitionTo(CircuitBreakerState.CLOSED);
+            metrics.reset();
+            lastOpenTime = null;
+            log.info("🔄 Slack Circuit Breaker 강제 리셋 완료");
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+}

--- a/src/main/java/com/marimo/server/global/circuitbreaker/SlackCircuitBreaker.java
+++ b/src/main/java/com/marimo/server/global/circuitbreaker/SlackCircuitBreaker.java
@@ -1,163 +1,124 @@
 package com.marimo.server.global.circuitbreaker;
 
-import java.time.Instant;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@RequiredArgsConstructor
 @Slf4j
 public class SlackCircuitBreaker {
 
     private final CircuitBreakerConfig config;
-    private final CircuitBreakerMetrics metrics;
+    private final CircuitBreakerMetrics metrics = new CircuitBreakerMetrics();
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private volatile CircuitBreakerState state = CircuitBreakerState.CLOSED;
-    private volatile Instant lastOpenTime;
+    private CircuitBreakerState state = CircuitBreakerState.CLOSED;
+    private long lastOpenAtMillis;
 
-    public SlackCircuitBreaker(CircuitBreakerConfig config) {
-        this.config = config;
-        this.metrics = new CircuitBreakerMetrics();
-    }
-
-    /**
-     * Slack 알림 시도 전 Circuit Breaker 상태 확인
-     *
-     * @return true if should use Slack (primary), false if should use Discord (fallback)
-     */
     public boolean canExecute() {
+        boolean shouldTransitionToHalfOpen = false;
+
         lock.readLock().lock();
         try {
-            CircuitBreakerState currentState = getCurrentState();
-
-            switch (currentState) {
-                case CLOSED:
-                    return true; // Slack 사용 가능
-                case OPEN:
-                    return false; // Discord로 fallback
-                case HALF_OPEN:
-                    // HALF_OPEN 상태에서는 제한적으로 Slack 시도
-                    return true;
-                default:
-                    return false;
+            if (state == CircuitBreakerState.OPEN && hasOpenTimeoutElapsed()) {
+                shouldTransitionToHalfOpen = true;
             }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        if (shouldTransitionToHalfOpen) {
+            lock.writeLock().lock();
+            try {
+                if (state == CircuitBreakerState.OPEN && hasOpenTimeoutElapsed()) {
+                    transitionTo(CircuitBreakerState.HALF_OPEN);
+                    log.info("🟡 Slack CB: OPEN → HALF_OPEN (타임아웃 {}ms 경과)", config.timeoutDuration());
+                }
+            } finally {
+                lock.writeLock().unlock();
+            }
+        }
+
+        lock.readLock().lock();
+        try {
+            return state == CircuitBreakerState.CLOSED || state == CircuitBreakerState.HALF_OPEN;
         } finally {
             lock.readLock().unlock();
         }
     }
 
-    /**
-     * Slack 알림 성공 시 호출
-     */
+    private boolean hasOpenTimeoutElapsed() {
+        return lastOpenAtMillis > 0 && (System.currentTimeMillis() - lastOpenAtMillis) >= config.timeoutDuration();
+    }
+
     public void recordSuccess() {
         lock.writeLock().lock();
         try {
             metrics.recordSuccess();
 
-            CircuitBreakerState currentState = getCurrentState();
-
-            if (currentState == CircuitBreakerState.HALF_OPEN) {
-                // HALF_OPEN 상태에서 연속 성공이 임계값에 도달하면 CLOSED로 전환
-                if (metrics.getConsecutiveSuccesses().get() >= config.getSuccessThreshold()) {
-                    transitionTo(CircuitBreakerState.CLOSED);
-                    log.info("🟢 Slack Circuit Breaker: HALF_OPEN → CLOSED (연속 성공 {}회)",
-                            metrics.getConsecutiveSuccesses().get());
-                }
+            if (state == CircuitBreakerState.HALF_OPEN && metrics.getSuccessStreak() >= config.successThreshold()) {
+                transitionTo(CircuitBreakerState.CLOSED);
+                log.info("🟢 Slack CB: HALF_OPEN → CLOSED (연속 {}회 성공)", metrics.getSuccessStreak());
             }
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    /**
-     * Slack 알림 실패 시 호출
-     */
     public void recordFailure() {
         lock.writeLock().lock();
         try {
             metrics.recordFailure();
 
-            CircuitBreakerState currentState = getCurrentState();
+            if (state == CircuitBreakerState.HALF_OPEN) {
+                transitionTo(CircuitBreakerState.OPEN);
+                lastOpenAtMillis = System.currentTimeMillis();
+                log.warn("🔴 Slack CB: HALF_OPEN → OPEN (테스트 실패)");
 
-            if (currentState == CircuitBreakerState.CLOSED || currentState == CircuitBreakerState.HALF_OPEN) {
-                // 연속 실패가 임계값에 도달하면 OPEN으로 전환
-                if (metrics.getConsecutiveFailures().get() >= config.getFailureThreshold()) {
-                    transitionTo(CircuitBreakerState.OPEN);
-                    log.warn("🔴 Slack Circuit Breaker: {} → OPEN (연속 실패 {}회), Discord로 fallback 시작",
-                            currentState, metrics.getConsecutiveFailures().get());
-                    lastOpenTime = Instant.now();
-                }
+                return;
+            }
+
+            if (state == CircuitBreakerState.CLOSED && metrics.getFailureStreak() >= config.failureThreshold()) {
+                transitionTo(CircuitBreakerState.OPEN);
+                lastOpenAtMillis = System.currentTimeMillis();
+                log.warn("🔴 Slack CB: CLOSED → OPEN (연속 {}회 실패), Discord로 fallback 시작", metrics.getFailureStreak());
             }
         } finally {
             lock.writeLock().unlock();
         }
     }
 
-    /**
-     * 현재 상태를 반환 (시간 기반 상태 전환 포함)
-     */
-    private CircuitBreakerState getCurrentState() {
-        if (state == CircuitBreakerState.OPEN && lastOpenTime != null) {
-            long timeSinceOpened = Instant.now().toEpochMilli() - lastOpenTime.toEpochMilli();
-
-            if (timeSinceOpened >= config.getTimeoutDuration()) {
-                transitionTo(CircuitBreakerState.HALF_OPEN);
-                log.info("🟡 Slack Circuit Breaker: OPEN → HALF_OPEN (타임아웃 {}ms 경과)",
-                        config.getTimeoutDuration());
-            }
-        }
-
-        return state;
-    }
-
-    private void transitionTo(CircuitBreakerState newState) {
-        CircuitBreakerState oldState = this.state;
+    // 항상 write 락을 보유한 상태에서만 호출되어야 함
+    private void transitionTo(final CircuitBreakerState newState) {
         this.state = newState;
         metrics.recordStateChange();
 
         if (newState == CircuitBreakerState.CLOSED) {
-            metrics.reset(); // CLOSED로 전환 시 메트릭 리셋
-        }
-
-        if (oldState != newState) {
-            log.info("Circuit Breaker 상태 변경: {} → {}", oldState, newState);
+            metrics.reset();
         }
     }
 
-    /**
-     * Circuit Breaker 상태 정보 조회
-     */
     public CircuitBreakerStatus getStatus() {
         lock.readLock().lock();
         try {
             return CircuitBreakerStatus.builder()
-                    .state(getCurrentState())
-                    .totalCalls(metrics.getTotalCalls().get())
-                    .failedCalls(metrics.getFailedCalls().get())
-                    .successfulCalls(metrics.getSuccessfulCalls().get())
-                    .consecutiveFailures(metrics.getConsecutiveFailures().get())
-                    .consecutiveSuccesses(metrics.getConsecutiveSuccesses().get())
-                    .failureRate(metrics.getFailureRate())
-                    .lastFailureTime(metrics.getLastFailureTime())
-                    .lastSuccessTime(metrics.getLastSuccessTime())
-                    .lastStateChangeTime(metrics.getLastStateChangeTime())
+                    .state(state)
+                    .metrics(metrics)
                     .build();
         } finally {
             lock.readLock().unlock();
         }
     }
 
-    /**
-     * Circuit Breaker 강제 리셋 (관리용)
-     */
     public void reset() {
         lock.writeLock().lock();
         try {
             transitionTo(CircuitBreakerState.CLOSED);
             metrics.reset();
-            lastOpenTime = null;
-            log.info("🔄 Slack Circuit Breaker 강제 리셋 완료");
+            lastOpenAtMillis = 0L;
         } finally {
             lock.writeLock().unlock();
+            log.info("🔄 Slack CB: 강제 리셋 완료");
         }
     }
 }

--- a/src/main/java/com/marimo/server/global/config/AsyncConfig.java
+++ b/src/main/java/com/marimo/server/global/config/AsyncConfig.java
@@ -21,4 +21,16 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "errorNotificationTaskExecutor")
+    public Executor errorNotificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);        // 에러는 자주 발생하지 않으므로 1개로 시작
+        executor.setMaxPoolSize(3);         // 최대 3개로 충분
+        executor.setQueueCapacity(50);      // 에러 큐는 작게
+        executor.setThreadNamePrefix("ErrorNotification-");
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/marimo/server/global/config/AsyncConfig.java
+++ b/src/main/java/com/marimo/server/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.marimo.server.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "orderNotificationTaskExecutor")
+    public Executor orderNotificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("OrderNotification-");
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/marimo/server/global/event/ErrorEvent.java
+++ b/src/main/java/com/marimo/server/global/event/ErrorEvent.java
@@ -1,0 +1,27 @@
+package com.marimo.server.global.event;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorEvent {
+    private final Exception exception;
+    private final HttpServletRequest request;
+    private final LocalDateTime occurredAt;
+    private final String errorId;
+
+    public ErrorEvent(Exception exception, HttpServletRequest request) {
+        this.exception = exception;
+        this.request = request;
+        this.occurredAt = LocalDateTime.now();
+        this.errorId = generateErrorId();
+    }
+
+    private String generateErrorId() {
+        return "ERR-" + System.currentTimeMillis() + "-" + 
+               Integer.toHexString(this.hashCode()).substring(0, 4).toUpperCase();
+    }
+}

--- a/src/main/java/com/marimo/server/global/event/InvitationOrderCreatedEvent.java
+++ b/src/main/java/com/marimo/server/global/event/InvitationOrderCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.marimo.server.global.event;
+
+import com.marimo.server.domain.order.dto.request.InvitationOrderRequest;
+import com.marimo.server.domain.order.dto.response.OrderResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class InvitationOrderCreatedEvent {
+
+    private final InvitationOrderRequest request;
+    private final OrderResponse response;
+}

--- a/src/main/java/com/marimo/server/global/event/PreVideoOrderCreatedEvent.java
+++ b/src/main/java/com/marimo/server/global/event/PreVideoOrderCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.marimo.server.global.event;
+
+import com.marimo.server.domain.order.dto.request.PreVideoOrderRequest;
+import com.marimo.server.domain.order.dto.response.OrderResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PreVideoOrderCreatedEvent {
+
+    private final PreVideoOrderRequest request;
+    private final OrderResponse response;
+}

--- a/src/main/java/com/marimo/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/marimo/server/global/exception/GlobalExceptionHandler.java
@@ -115,7 +115,7 @@ public class GlobalExceptionHandler {
     // 기타 에러 발생 시 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGeneralException(Exception e) {
-        log.error("알 수 없는 예외 발생: {}", e.getClass().getName());
+        log.error("알 수 없는 예외 발생: {}", e.getClass().getName(), e);
         log.error("에러 메시지: {}", e.getMessage());
 
         return ResponseEntity

--- a/src/main/java/com/marimo/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/marimo/server/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,14 @@
 package com.marimo.server.global.exception;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.marimo.server.global.event.ErrorEvent;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -17,8 +21,11 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private final ApplicationEventPublisher eventPublisher;
 
     // @Validated 유효성 검사 시 예외 처리
     @ExceptionHandler(ConstraintViolationException.class)
@@ -114,9 +121,9 @@ public class GlobalExceptionHandler {
 
     // 기타 에러 발생 시 예외 처리
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleGeneralException(Exception e, HttpServletRequest request) {
+        eventPublisher.publishEvent(new ErrorEvent(e, request));
         log.error("알 수 없는 예외 발생: {}", e.getClass().getName(), e);
-        log.error("에러 메시지: {}", e.getMessage());
 
         return ResponseEntity
                 .status(ErrorType.INTERNAL_SERVER_ERROR.getHttpStatus())

--- a/src/main/java/com/marimo/server/global/logging/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/marimo/server/global/logging/CachedBodyHttpServletRequest.java
@@ -1,0 +1,49 @@
+package com.marimo.server.global.logging;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest(final HttpServletRequest request) throws IOException {
+        super(request);
+        this.cachedBody = request.getInputStream().readAllBytes();
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return new ServletInputStream() {
+            private final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(cachedBody);
+
+            @Override
+            public int read() throws IOException {
+                return byteArrayInputStream.read();
+            }
+
+            @Override
+            public boolean isFinished() {
+                return byteArrayInputStream.available() <= 0;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+            }
+        };
+    }
+
+    public String getBody() {
+        return new String(cachedBody, StandardCharsets.UTF_8).replaceAll("\\s", "");
+    }
+}

--- a/src/main/java/com/marimo/server/global/logging/FailedNotificationAppender.java
+++ b/src/main/java/com/marimo/server/global/logging/FailedNotificationAppender.java
@@ -1,0 +1,85 @@
+package com.marimo.server.global.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.marimo.server.global.notification.FailedNotificationRecord;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FailedNotificationAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Setter
+    private String logPath = "./logs/failed-notifications"; // 기본 경로
+
+    @Override
+    public void start() {
+        // 로그 디렉토리 생성
+        try {
+            Path path = Paths.get(logPath);
+            if (!Files.exists(path)) {
+                Files.createDirectories(path);
+                log.info("📁 실패 알림 로그 디렉토리 생성: {}", path.toAbsolutePath());
+            }
+        } catch (IOException e) {
+            addError("실패 알림 로그 디렉토리 생성 실패: " + logPath, e);
+        }
+
+        super.start();
+    }
+
+    public void logFailedNotification(
+            ILoggingEvent event,
+            String failureReason,
+            boolean slackFailed,
+            boolean discordFailed
+    ) {
+        try {
+            FailedNotificationRecord record = FailedNotificationRecord.fromLoggingEvent(
+                    event, failureReason, slackFailed, discordFailed
+            );
+
+            writeToFile(record);
+
+            log.warn("💾 실패 알림 저장됨 - ID: {}, TraceID: {}, 사유: {}",
+                    record.getId(), record.getTraceId(), record.getFailureReason());
+
+        } catch (Exception e) {
+            addError("실패 알림 로그 저장 중 에러 발생", e);
+        }
+    }
+
+    private void writeToFile(FailedNotificationRecord record) throws IOException {
+        String fileName = generateFileName();
+        File file = new File(logPath, fileName);
+
+        try (FileWriter writer = new FileWriter(file, true)) {
+            String json = OBJECT_MAPPER.writeValueAsString(record);
+            writer.write(json + System.lineSeparator());
+        }
+    }
+
+    private String generateFileName() {
+        // 날짜별로 파일 분리: failed-notifications-2025-01-15.json
+        String dateStr = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        return "failed-notifications-" + dateStr + ".json";
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        // 이 appender는 직접 호출되지 않고, logFailedNotification 메서드를 통해 사용됨
+    }
+}

--- a/src/main/java/com/marimo/server/global/logging/FallbackNotificationAppender.java
+++ b/src/main/java/com/marimo/server/global/logging/FallbackNotificationAppender.java
@@ -1,0 +1,382 @@
+package com.marimo.server.global.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.marimo.server.global.circuitbreaker.CircuitBreakerConfig;
+import com.marimo.server.global.circuitbreaker.SlackCircuitBreaker;
+import com.marimo.server.global.webhook.DiscordWebhookAdapter;
+import com.marimo.server.global.webhook.Embed;
+import com.marimo.server.global.webhook.ExecuteWebhookRequest;
+import com.marimo.server.global.webhook.Field;
+import com.marimo.server.global.webhook.SlackAttachment;
+import com.marimo.server.global.webhook.SlackField;
+import com.marimo.server.global.webhook.SlackWebhookAdapter;
+import com.marimo.server.global.webhook.SlackWebhookRequest;
+import java.awt.Color;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+public class FallbackNotificationAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter SEOUL_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS").withZone(SEOUL_ZONE);
+    private static final int MAX_EMBED_DESCRIPTION_LENGTH = 4096;
+    private static final Cache<String, Boolean> loggedTraceIds = Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .initialCapacity(20)
+            .maximumSize(100)
+            .build();
+
+    @Setter
+    private String username;
+
+    @Setter
+    private String avatarUrl;
+
+    @Setter
+    private String slackWebhookUrl;
+
+    @Setter
+    private String discordWebhookUrl;
+
+    // Circuit Breaker 설정
+    @Setter
+    private int failureThreshold = 5;
+
+    @Setter
+    private int successThreshold = 3;
+
+    @Setter
+    private long timeoutDuration = 60000; // 1분
+
+    private SlackCircuitBreaker circuitBreaker;
+    private FailedNotificationAppender failedNotificationAppender;
+
+    @Override
+    public void start() {
+        // Circuit Breaker 초기화
+        CircuitBreakerConfig config = new CircuitBreakerConfig();
+        config.setFailureThreshold(failureThreshold);
+        config.setSuccessThreshold(successThreshold);
+        config.setTimeoutDuration(timeoutDuration);
+
+        this.circuitBreaker = new SlackCircuitBreaker(config);
+
+        // Failed Notification Appender 초기화
+        this.failedNotificationAppender = new FailedNotificationAppender();
+        this.failedNotificationAppender.start();
+
+        log.info("🔧 FallbackNotificationAppender 시작됨 - Circuit Breaker 설정: " +
+                        "실패임계값={}, 성공임계값={}, 타임아웃={}ms",
+                failureThreshold, successThreshold, timeoutDuration);
+
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        String traceId = getMdcValue(event.getMDCPropertyMap(), "traceId");
+
+        // Circuit Breaker 상태 확인
+        if (circuitBreaker.canExecute()) {
+            // Slack 우선 시도
+            sendSlackNotificationWithFallback(event, traceId);
+        } else {
+            // Circuit Breaker가 OPEN 상태면 바로 Discord로 fallback
+            log.debug("🔴 Circuit Breaker OPEN - Discord fallback 사용: {}", traceId);
+            sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+        }
+    }
+
+    private void sendSlackNotificationWithFallback(ILoggingEvent event, String traceId) {
+        if (slackWebhookUrl == null || slackWebhookUrl.isEmpty()) {
+            log.warn("Slack 웹훅 URL이 설정되지 않음 - Discord로 fallback");
+            sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+            return;
+        }
+
+        SlackWebhookAdapter slackWebhookAdapter = new SlackWebhookAdapter(slackWebhookUrl);
+        SlackWebhookRequest slackRequest = createSlackRequest(event);
+
+        Callback slackCallback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                // Slack 실패 시 Circuit Breaker에 실패 기록
+                circuitBreaker.recordFailure();
+
+                logWebhookFailure("Slack", traceId, e);
+
+                // Discord로 fallback 시도
+                log.warn("🔴 Slack 알림 실패 - Discord로 fallback: {}", traceId);
+                sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        // Slack 성공 시 Circuit Breaker에 성공 기록
+                        circuitBreaker.recordSuccess();
+                        log.debug("✅ Slack 알림 성공: {}", traceId);
+                    } else {
+                        // HTTP 에러 응답도 실패로 처리
+                        circuitBreaker.recordFailure();
+                        log.error("🔴 Slack 알림 HTTP 에러 ({}), Discord로 fallback: {}", response.code(), traceId);
+                        sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+                    }
+                } catch (Exception e) {
+                    circuitBreaker.recordFailure();
+                    log.error("🔴 Slack 응답 처리 중 에러, Discord로 fallback: {}", traceId, e);
+                    sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+                }
+            }
+        };
+
+        slackWebhookAdapter.execute(slackRequest, slackCallback);
+    }
+
+    private void sendDiscordNotificationWithFailureTracking(
+            ILoggingEvent event,
+            String traceId,
+            boolean isFallback,
+            boolean slackFailed,
+            boolean discordFailed
+    ) {
+        if (discordWebhookUrl == null || discordWebhookUrl.isEmpty()) {
+            log.error("Discord 웹훅 URL이 설정되지 않음 - 양쪽 플랫폼 모두 실패: {}", traceId);
+
+            // 양쪽 모두 실패했으므로 실패 알림 로그에 저장
+            failedNotificationAppender.logFailedNotification(event, "BOTH_FAILED", true, true);
+            return;
+        }
+
+        DiscordWebhookAdapter discordWebhookAdapter = new DiscordWebhookAdapter(discordWebhookUrl);
+        ExecuteWebhookRequest discordRequest = createDiscordRequest(event, isFallback);
+
+        Callback discordCallback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                logWebhookFailure("Discord" + (isFallback ? " (Fallback)" : ""), traceId, e);
+
+                // Discord도 실패했으므로 실패 알림 로그에 저장
+                String failureReason = slackFailed ? "BOTH_FAILED" : "DISCORD_FAILED";
+                failedNotificationAppender.logFailedNotification(
+                        event,
+                        failureReason,
+                        slackFailed,
+                        true
+                );
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        log.debug("✅ Discord 알림 성공{}: {}", isFallback ? " (Fallback)" : "", traceId);
+                    } else {
+                        log.error("🔴 Discord 알림 HTTP 에러 ({}){}: {}", response.code(),
+                                isFallback ? " (Fallback)" : "", traceId);
+
+                        // HTTP 에러도 실패로 처리
+                        String failureReason = slackFailed ? "BOTH_FAILED" : "DISCORD_FAILED";
+                        failedNotificationAppender.logFailedNotification(
+                                event,
+                                failureReason,
+                                slackFailed,
+                                true
+                        );
+                    }
+                } catch (Exception e) {
+                    log.error("🔴 Discord 응답 처리 중 에러{}: {}", isFallback ? " (Fallback)" : "", traceId, e);
+
+                    // 응답 처리 에러도 실패로 처리
+                    String failureReason = slackFailed ? "BOTH_FAILED" : "DISCORD_FAILED";
+                    failedNotificationAppender.logFailedNotification(
+                            event,
+                            failureReason,
+                            slackFailed,
+                            true
+                    );
+                }
+            }
+        };
+
+        discordWebhookAdapter.execute(discordRequest, discordCallback);
+    }
+
+    private SlackWebhookRequest createSlackRequest(ILoggingEvent event) {
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        String mainText = throwableProxy != null ?
+                "🚨 *MARIMO SERVER EXCEPTION 발생*" :
+                "⚠️ *MARIMO SERVER ERROR 발생*";
+
+        SlackWebhookRequest slackRequest = new SlackWebhookRequest(username, avatarUrl, mainText);
+
+        String slackColor = getSlackLevelColor(event);
+        String timestamp = String.valueOf(event.getTimeStamp() / 1000);
+        String title = throwableProxy != null ? "Exception occurred!" : "Error occurred!";
+        String exceptionOverview = throwableProxy != null
+                ? throwableProxy.getClassName() + ": " + throwableProxy.getMessage()
+                : event.getFormattedMessage();
+
+        SlackAttachment attachment = new SlackAttachment(slackColor, title, exceptionOverview, timestamp);
+
+        Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+        String traceId = getMdcValue(mdcPropertyMap, "traceId");
+
+        attachment.addField(new SlackField("에러 발생 시각", formatToSeoulTime(event.getTimeStamp()), true));
+        attachment.addField(new SlackField("Trace ID", traceId, true));
+        attachment.addField(new SlackField("유저 IP", getMdcValue(mdcPropertyMap, "clientIp"), true));
+        attachment.addField(new SlackField("요청 URI", getMdcValue(mdcPropertyMap, "requestURI"), false));
+        attachment.addField(new SlackField("요청 Parameters", getMdcValue(mdcPropertyMap, "requestParams"), false));
+        attachment.addField(new SlackField("요청 Body", getMdcValue(mdcPropertyMap, "requestBody"), false));
+
+        slackRequest.addAttachment(attachment);
+
+        if (throwableProxy != null) {
+            String exceptionDetail = getFullStackTrace(throwableProxy);
+            exceptionDetail = exceptionDetail.length() > 1000
+                    ? exceptionDetail.substring(0, 1000) + "..."
+                    : exceptionDetail;
+
+            SlackAttachment exceptionAttachment = new SlackAttachment(slackColor, "Exception 상세 내용",
+                    "```\n" + exceptionDetail + "\n```", null);
+            slackRequest.addAttachment(exceptionAttachment);
+        }
+
+        return slackRequest;
+    }
+
+    private ExecuteWebhookRequest createDiscordRequest(ILoggingEvent event, boolean isFallback) {
+        ExecuteWebhookRequest executeWebhookRequest = new ExecuteWebhookRequest(username, avatarUrl);
+
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
+        String title = throwableProxy != null ? "Exception occurred!" : "Error occurred!";
+        if (isFallback) {
+            title += " 🔄 [Slack Fallback]";
+        }
+
+        String exceptionOverview = throwableProxy != null
+                ? throwableProxy.getClassName() + ": " + throwableProxy.getMessage()
+                : event.getFormattedMessage();
+
+        int embedColor = getLevelColor(event);
+        String timestamp = formatToSeoulTime(event.getTimeStamp());
+        Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+        String traceId = getMdcValue(mdcPropertyMap, "traceId");
+
+        Embed embed = new Embed(title, exceptionOverview, embedColor, null);
+
+        embed.addField(new Field("[에러 발생 시각]", timestamp, false));
+        embed.addField(new Field("[Trace ID]", traceId, false));
+        if (isFallback) {
+            embed.addField(new Field("[알림 방식]", "🔄 Slack → Discord Fallback", false));
+        }
+        embed.addField(new Field("[유저 IP 정보]", getMdcValue(mdcPropertyMap, "clientIp"), false));
+        embed.addField(new Field("[요청 URI 정보]", getMdcValue(mdcPropertyMap, "requestURI"), false));
+        embed.addField(new Field("[요청 Parameter 정보]", getMdcValue(mdcPropertyMap, "requestParams"), false));
+        embed.addField(new Field("[요청 Header 정보]", getMdcValue(mdcPropertyMap, "requestHeaders"), false));
+        embed.addField(new Field("[요청 Body 정보]", getMdcValue(mdcPropertyMap, "requestBody"), false));
+
+        executeWebhookRequest.addEmbed(embed);
+
+        if (throwableProxy != null) {
+            String exceptionDetail = getFullStackTrace(throwableProxy);
+            exceptionDetail = exceptionDetail.length() > MAX_EMBED_DESCRIPTION_LENGTH
+                    ? exceptionDetail.substring(0, MAX_EMBED_DESCRIPTION_LENGTH - 3) + "..."
+                    : exceptionDetail;
+
+            embed = new Embed("[Exception 상세 내용]", exceptionDetail, embedColor, null);
+            executeWebhookRequest.addEmbed(embed);
+        }
+
+        return executeWebhookRequest;
+    }
+
+    private void logWebhookFailure(String platform, String traceId, IOException e) {
+        if (!traceId.equals("N/A")) {
+            if (loggedTraceIds.getIfPresent(traceId) == null) {
+                loggedTraceIds.put(traceId, true);
+                log.error("{} 웹훅 실행 실패: {}", platform, traceId, e);
+            } else {
+                log.warn("{} 웹훅 실행 실패 (중복): {}", platform, traceId);
+            }
+        } else {
+            log.warn("{} 웹훅 실행 실패", platform, e);
+        }
+    }
+
+    // Circuit Breaker 상태 조회 메서드 (관리용)
+    public SlackCircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    private static int getLevelColor(ILoggingEvent event) {
+        return switch (event.getLevel().toInt()) {
+            case Level.ERROR_INT -> Color.red.getRGB() & 0xFFFFFF;
+            case Level.WARN_INT -> Color.yellow.getRGB() & 0xFFFFFF;
+            default -> Color.blue.getRGB() & 0xFFFFFF;
+        };
+    }
+
+    private static String getSlackLevelColor(ILoggingEvent event) {
+        return switch (event.getLevel().toInt()) {
+            case Level.ERROR_INT -> "danger";
+            case Level.WARN_INT -> "warning";
+            default -> "good";
+        };
+    }
+
+    private static String formatToSeoulTime(long timestamp) {
+        ZonedDateTime seoulTime = Instant.ofEpochMilli(timestamp).atZone(SEOUL_ZONE);
+        return SEOUL_TIME_FORMATTER.format(seoulTime);
+    }
+
+    private static String getMdcValue(Map<String, String> mdcPropertyMap, String key) {
+        return mdcPropertyMap.getOrDefault(key, "N/A");
+    }
+
+    private static String getFullStackTrace(IThrowableProxy exceptionProxy) {
+        StringBuilder fullStackTrace = new StringBuilder();
+
+        while (exceptionProxy != null) {
+            fullStackTrace.append(exceptionProxy.getClassName())
+                    .append(": ")
+                    .append(exceptionProxy.getMessage())
+                    .append("\n");
+
+            var stackTraceElements = exceptionProxy.getStackTraceElementProxyArray();
+            int limit = Math.min(stackTraceElements.length, 5);
+
+            for (int i = 0; i < limit; i++) {
+                String ste = stackTraceElements[i].getSTEAsString();
+                fullStackTrace.append(ste).append("\n");
+            }
+
+            exceptionProxy = exceptionProxy.getCause();
+
+            if (exceptionProxy != null) {
+                fullStackTrace.append("Caused by: ");
+            }
+        }
+
+        return fullStackTrace.toString();
+    }
+}

--- a/src/main/java/com/marimo/server/global/logging/OrderNotificationAppender.java
+++ b/src/main/java/com/marimo/server/global/logging/OrderNotificationAppender.java
@@ -1,0 +1,331 @@
+package com.marimo.server.global.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.marimo.server.global.circuitbreaker.CircuitBreakerConfig;
+import com.marimo.server.global.circuitbreaker.SlackCircuitBreaker;
+import com.marimo.server.global.webhook.DiscordWebhookAdapter;
+import com.marimo.server.global.webhook.Embed;
+import com.marimo.server.global.webhook.ExecuteWebhookRequest;
+import com.marimo.server.global.webhook.Field;
+import com.marimo.server.global.webhook.SlackAttachment;
+import com.marimo.server.global.webhook.SlackField;
+import com.marimo.server.global.webhook.SlackWebhookAdapter;
+import com.marimo.server.global.webhook.SlackWebhookRequest;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+@Slf4j
+public class OrderNotificationAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter SEOUL_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS").withZone(SEOUL_ZONE);
+    private static final int MAX_EMBED_DESCRIPTION_LENGTH = 4096;
+    private static final Cache<String, Boolean> loggedTraceIds = Caffeine.newBuilder()
+            .expireAfterWrite(5, TimeUnit.MINUTES)
+            .initialCapacity(20)
+            .maximumSize(100)
+            .build();
+
+    @Setter
+    private String username;
+
+    @Setter
+    private String avatarUrl;
+
+    @Setter
+    private String slackWebhookUrl;
+
+    @Setter
+    private String discordWebhookUrl;
+
+    // Circuit Breaker 설정 (에러 알림과 동일)
+    @Setter
+    private int failureThreshold = 5;
+
+    @Setter
+    private int successThreshold = 3;
+
+    @Setter
+    private long timeoutDuration = 60000; // 1분
+
+    private SlackCircuitBreaker circuitBreaker;
+    private FailedNotificationAppender failedNotificationAppender;
+
+    @Override
+    public void start() {
+        // Circuit Breaker 초기화
+        CircuitBreakerConfig config = new CircuitBreakerConfig();
+        config.setFailureThreshold(failureThreshold);
+        config.setSuccessThreshold(successThreshold);
+        config.setTimeoutDuration(timeoutDuration);
+
+        this.circuitBreaker = new SlackCircuitBreaker(config);
+
+        // Failed Notification Appender 초기화
+        this.failedNotificationAppender = new FailedNotificationAppender();
+        this.failedNotificationAppender.start();
+
+        log.info("🔧 OrderNotificationAppender 시작됨 - Circuit Breaker 설정: " +
+                        "실패임계값={}, 성공임계값={}, 타임아웃={}ms",
+                failureThreshold, successThreshold, timeoutDuration);
+
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        // INFO 레벨의 주문 관련 로그만 처리
+        if (!event.getLevel().equals(Level.INFO)) {
+            return;
+        }
+
+        // 주문 관련 로그인지 확인 (특정 마커나 메시지 패턴으로 필터링)
+        String message = event.getFormattedMessage();
+        if (!isOrderNotification(message)) {
+            return;
+        }
+
+        String traceId = getMdcValue(event.getMDCPropertyMap(), "traceId");
+
+        // Circuit Breaker 상태 확인
+        if (circuitBreaker.canExecute()) {
+            // Slack 우선 시도
+            sendSlackNotificationWithFallback(event, traceId);
+        } else {
+            // Circuit Breaker가 OPEN 상태면 바로 Discord로 fallback
+            log.debug("🔴 Circuit Breaker OPEN - Discord fallback 사용 (주문 알림): {}", traceId);
+            sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+        }
+    }
+
+    private boolean isOrderNotification(String message) {
+        // 주문 성공 알림을 구분하는 패턴
+        return message != null && (
+                message.contains("[주문 성공]") ||
+                        message.contains("[ORDER_SUCCESS]") ||
+                        message.startsWith("🎉 새로운 주문이 접수되었습니다")
+        );
+    }
+
+    private void sendSlackNotificationWithFallback(ILoggingEvent event, String traceId) {
+        if (slackWebhookUrl == null || slackWebhookUrl.isEmpty()) {
+            log.warn("Slack 웹훅 URL이 설정되지 않음 - Discord로 fallback (주문 알림)");
+            sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+            return;
+        }
+
+        SlackWebhookAdapter slackWebhookAdapter = new SlackWebhookAdapter(slackWebhookUrl);
+        SlackWebhookRequest slackRequest = createSlackRequest(event);
+
+        Callback slackCallback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                // Slack 실패 시 Circuit Breaker에 실패 기록
+                circuitBreaker.recordFailure();
+
+                logWebhookFailure("Slack (주문 알림)", traceId, e);
+
+                // Discord로 fallback 시도
+                log.warn("🔴 Slack 주문 알림 실패 - Discord로 fallback: {}", traceId);
+                sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        // Slack 성공 시 Circuit Breaker에 성공 기록
+                        circuitBreaker.recordSuccess();
+                        log.debug("✅ Slack 주문 알림 성공: {}", traceId);
+                    } else {
+                        // HTTP 에러 응답도 실패로 처리
+                        circuitBreaker.recordFailure();
+                        log.error("🔴 Slack 주문 알림 HTTP 에러 ({}), Discord로 fallback: {}", response.code(), traceId);
+                        sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+                    }
+                } catch (Exception e) {
+                    circuitBreaker.recordFailure();
+                    log.error("🔴 Slack 주문 알림 응답 처리 중 에러, Discord로 fallback: {}", traceId, e);
+                    sendDiscordNotificationWithFailureTracking(event, traceId, true, true, false);
+                }
+            }
+        };
+
+        slackWebhookAdapter.execute(slackRequest, slackCallback);
+    }
+
+    private void sendDiscordNotificationWithFailureTracking(
+            ILoggingEvent event,
+            String traceId,
+            boolean isFallback,
+            boolean slackFailed,
+            boolean discordFailed
+    ) {
+        if (discordWebhookUrl == null || discordWebhookUrl.isEmpty()) {
+            log.error("Discord 웹훅 URL이 설정되지 않음 - 양쪽 플랫폼 모두 실패 (주문 알림): {}", traceId);
+
+            // 양쪽 모두 실패했으므로 실패 알림 로그에 저장
+            failedNotificationAppender.logFailedNotification(event, "ORDER_NOTIFICATION_BOTH_FAILED", true, true);
+            return;
+        }
+
+        DiscordWebhookAdapter discordWebhookAdapter = new DiscordWebhookAdapter(discordWebhookUrl);
+        ExecuteWebhookRequest discordRequest = createDiscordRequest(event, isFallback);
+
+        Callback discordCallback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                logWebhookFailure("Discord (주문 알림)" + (isFallback ? " (Fallback)" : ""), traceId, e);
+
+                // Discord도 실패했으므로 실패 알림 로그에 저장
+                String failureReason =
+                        slackFailed ? "ORDER_NOTIFICATION_BOTH_FAILED" : "ORDER_NOTIFICATION_DISCORD_FAILED";
+                failedNotificationAppender.logFailedNotification(
+                        event,
+                        failureReason,
+                        slackFailed,
+                        true
+                );
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        log.debug("✅ Discord 주문 알림 성공{}: {}", isFallback ? " (Fallback)" : "", traceId);
+                    } else {
+                        log.error("🔴 Discord 주문 알림 HTTP 에러 ({}){}: {}", response.code(),
+                                isFallback ? " (Fallback)" : "", traceId);
+
+                        // HTTP 에러도 실패로 처리
+                        String failureReason =
+                                slackFailed ? "ORDER_NOTIFICATION_BOTH_FAILED" : "ORDER_NOTIFICATION_DISCORD_FAILED";
+                        failedNotificationAppender.logFailedNotification(
+                                event,
+                                failureReason,
+                                slackFailed,
+                                true
+                        );
+                    }
+                } catch (Exception e) {
+                    log.error("🔴 Discord 주문 알림 응답 처리 중 에러{}: {}", isFallback ? " (Fallback)" : "", traceId, e);
+
+                    // 응답 처리 에러도 실패로 처리
+                    String failureReason =
+                            slackFailed ? "ORDER_NOTIFICATION_BOTH_FAILED" : "ORDER_NOTIFICATION_DISCORD_FAILED";
+                    failedNotificationAppender.logFailedNotification(
+                            event,
+                            failureReason,
+                            slackFailed,
+                            true
+                    );
+                }
+            }
+        };
+
+        discordWebhookAdapter.execute(discordRequest, discordCallback);
+    }
+
+    private SlackWebhookRequest createSlackRequest(ILoggingEvent event) {
+        String mainText = "🎉 *MARIMO 새로운 주문 접수*";
+
+        SlackWebhookRequest slackRequest = new SlackWebhookRequest(username, avatarUrl, mainText);
+
+        String slackColor = "good"; // 성공 알림은 녹색
+        String timestamp = String.valueOf(event.getTimeStamp() / 1000);
+        String title = "새로운 주문이 들어왔습니다!";
+        String orderMessage = event.getFormattedMessage();
+
+        SlackAttachment attachment = new SlackAttachment(slackColor, title, orderMessage, timestamp);
+
+        Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+        String traceId = getMdcValue(mdcPropertyMap, "traceId");
+
+        attachment.addField(new SlackField("주문 접수 시각", formatToSeoulTime(event.getTimeStamp()), true));
+        attachment.addField(new SlackField("Trace ID", traceId, true));
+        attachment.addField(new SlackField("고객 IP", getMdcValue(mdcPropertyMap, "clientIp"), true));
+        attachment.addField(new SlackField("요청 URI", getMdcValue(mdcPropertyMap, "requestURI"), false));
+        attachment.addField(new SlackField("요청 Parameters", getMdcValue(mdcPropertyMap, "requestParams"), false));
+        attachment.addField(new SlackField("요청 Body", getMdcValue(mdcPropertyMap, "requestBody"), false));
+
+        slackRequest.addAttachment(attachment);
+
+        return slackRequest;
+    }
+
+    private ExecuteWebhookRequest createDiscordRequest(ILoggingEvent event, boolean isFallback) {
+        ExecuteWebhookRequest executeWebhookRequest = new ExecuteWebhookRequest(username, avatarUrl);
+
+        String title = "새로운 주문이 들어왔습니다!";
+        if (isFallback) {
+            title += " 🔄 [Slack Fallback]";
+        }
+
+        String orderMessage = event.getFormattedMessage();
+
+        int embedColor = 0x00FF00; // 녹색 (성공 알림)
+        String timestamp = formatToSeoulTime(event.getTimeStamp());
+        Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
+        String traceId = getMdcValue(mdcPropertyMap, "traceId");
+
+        Embed embed = new Embed(title, orderMessage, embedColor, null);
+
+        embed.addField(new Field("[주문 접수 시각]", timestamp, false));
+        embed.addField(new Field("[Trace ID]", traceId, false));
+        if (isFallback) {
+            embed.addField(new Field("[알림 방식]", "🔄 Slack → Discord Fallback", false));
+        }
+        embed.addField(new Field("[고객 IP 정보]", getMdcValue(mdcPropertyMap, "clientIp"), false));
+        embed.addField(new Field("[요청 URI 정보]", getMdcValue(mdcPropertyMap, "requestURI"), false));
+        embed.addField(new Field("[요청 Parameter 정보]", getMdcValue(mdcPropertyMap, "requestParams"), false));
+        embed.addField(new Field("[요청 Header 정보]", getMdcValue(mdcPropertyMap, "requestHeaders"), false));
+        embed.addField(new Field("[요청 Body 정보]", getMdcValue(mdcPropertyMap, "requestBody"), false));
+
+        executeWebhookRequest.addEmbed(embed);
+
+        return executeWebhookRequest;
+    }
+
+    private void logWebhookFailure(String platform, String traceId, IOException e) {
+        if (!traceId.equals("N/A")) {
+            if (loggedTraceIds.getIfPresent(traceId) == null) {
+                loggedTraceIds.put(traceId, true);
+                log.error("{} 웹훅 실행 실패: {}", platform, traceId, e);
+            } else {
+                log.warn("{} 웹훅 실행 실패 (중복): {}", platform, traceId);
+            }
+        } else {
+            log.warn("{} 웹훅 실행 실패", platform, e);
+        }
+    }
+
+    // Circuit Breaker 상태 조회 메서드 (관리용)
+    public SlackCircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    private static String formatToSeoulTime(long timestamp) {
+        ZonedDateTime seoulTime = Instant.ofEpochMilli(timestamp).atZone(SEOUL_ZONE);
+        return SEOUL_TIME_FORMATTER.format(seoulTime);
+    }
+
+    private static String getMdcValue(Map<String, String> mdcPropertyMap, String key) {
+        return mdcPropertyMap.getOrDefault(key, "N/A");
+    }
+}

--- a/src/main/java/com/marimo/server/global/logging/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/marimo/server/global/logging/RequestResponseLoggingFilter.java
@@ -1,0 +1,173 @@
+package com.marimo.server.global.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Component
+@Order(1)
+@Slf4j
+public class RequestResponseLoggingFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+    private static final String TIMESTAMP = "timestamp";
+    private static final String CLIENT_IP = "clientIp";
+    private static final String REQUEST_URI = "requestURI";
+    private static final String REQUEST_PARAMS = "requestParams";
+    private static final String REQUEST_HEADERS = "requestHeaders";
+    private static final String REQUEST_BODY = "requestBody";
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter SEOUL_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS").withZone(SEOUL_ZONE);
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull final HttpServletRequest httpServletRequest,
+            @NonNull final HttpServletResponse httpServletResponse,
+            @NonNull final FilterChain filterChain
+    ) throws IOException, ServletException {
+        CachedBodyHttpServletRequest request = new CachedBodyHttpServletRequest(httpServletRequest);
+        ContentCachingResponseWrapper response = new ContentCachingResponseWrapper(httpServletResponse);
+
+        try {
+            MDC.put(TRACE_ID, UUID.randomUUID().toString());
+            MDC.put(TIMESTAMP, SEOUL_TIME_FORMATTER.format(Instant.now()));
+            MDC.put(CLIENT_IP, getClientIp(request));
+            MDC.put(REQUEST_URI, request.getRequestURI());
+            MDC.put(REQUEST_PARAMS, getRequestParams(request));
+            MDC.put(REQUEST_HEADERS, getRequestHeaders(request));
+
+            // Request의 Content-Type이 JSON인 경우에만 Request Body를 로깅
+            String requestBody = isJson(request.getContentType()) ? request.getBody() : "X";
+            MDC.put(REQUEST_BODY, requestBody);
+
+            String requestInfo = request.getMethod() + " | " + request.getRequestURI() + getQueryParams(request);
+            String requestLog = "[Request]  " + requestInfo + " | " + getClientIp(request);
+
+            if (!requestBody.equals("X")) {
+                requestLog += " | " + requestBody;
+            }
+
+            log.info(requestLog);
+
+            filterChain.doFilter(request, response);
+
+            // Response의 Content-Type이 JSON인 경우에만 Response Body를 로깅
+            String responseBody = isJson(response.getContentType()) ? getResponseBody(response) : "";
+            String responseLog = "[Response] " + requestInfo + " | " + response.getStatus();
+
+            if (!responseBody.isEmpty()) {
+                responseLog += " | " + responseBody;
+            }
+
+            log.info(responseLog);
+
+            // 캐싱된 Response Body를 클라이언트에게 전달하기 위해 실제 응답 스트림으로 다시 복사
+            response.copyBodyToResponse();
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private static String getQueryParams(final HttpServletRequest request) {
+        Map<String, String[]> parameterMap = request.getParameterMap();
+
+        if (parameterMap.isEmpty()) {
+            return "";
+        }
+
+        return parameterMap.entrySet().stream()
+                .flatMap(entry -> Arrays.stream(entry.getValue())
+                        .map(value -> entry.getKey() + "=" + value))
+                .collect(Collectors.joining("&", "?", ""));
+    }
+
+    // TODO: 정확한 클라이언트 IP 주소가 넘어오는지 확인
+    private static String getClientIp(final HttpServletRequest request) {
+        String requestAddr = request.getHeader(X_FORWARDED_FOR);
+
+        return (requestAddr != null) ? requestAddr : request.getRemoteAddr();
+    }
+
+    private static boolean isJson(String contentType) {
+        return contentType != null && contentType.toLowerCase().contains("application/json");
+    }
+
+    private static String getResponseBody(ContentCachingResponseWrapper response) {
+        // ContentCachingResponseWrapper에 캐싱된 Response Body를 가져와 UTF-8 문자열로 변환
+        return new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static String getRequestParams(final HttpServletRequest request) {
+        Map<String, String[]> parameterMap = request.getParameterMap();
+
+        if (parameterMap.isEmpty()) {
+            return "X";
+        }
+
+        StringBuilder requestParams = new StringBuilder();
+
+        for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+            requestParams.append(entry.getKey()).append(": ");
+
+            String[] values = entry.getValue();
+
+            for (int i = 0; i < values.length; i++) {
+                requestParams.append(values[i]);
+
+                if (i < values.length - 1) {
+                    requestParams.append(", ");
+                }
+            }
+
+            requestParams.append("\n");
+        }
+
+        return removeLastNewline(requestParams);
+    }
+
+    private static String getRequestHeaders(HttpServletRequest request) {
+        Enumeration<String> headerNames = request.getHeaderNames();
+
+        if (!headerNames.hasMoreElements()) {
+            return "X";
+        }
+
+        StringBuilder requestHeaders = new StringBuilder();
+
+        while (headerNames.hasMoreElements()) {
+            String name = headerNames.nextElement();
+            String value = request.getHeader(name);
+            requestHeaders.append(name).append(": ").append(value).append("\n");
+        }
+
+        return removeLastNewline(requestHeaders);
+    }
+
+    private static String removeLastNewline(StringBuilder sb) {
+        if (!sb.isEmpty() && sb.charAt(sb.length() - 1) == '\n') {
+            sb.setLength(sb.length() - 1);
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/marimo/server/global/notification/ErrorNotificationService.java
+++ b/src/main/java/com/marimo/server/global/notification/ErrorNotificationService.java
@@ -1,0 +1,131 @@
+package com.marimo.server.global.notification;
+
+import com.marimo.server.global.event.ErrorEvent;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Enumeration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ErrorNotificationService {
+
+    private static final Logger ERROR_LOGGER = LoggerFactory.getLogger("ERROR_NOTIFICATION");
+
+    @EventListener
+    @Async("errorNotificationTaskExecutor")
+    public void handleErrorOccurred(ErrorEvent event) {
+        try {
+            Exception exception = event.getException();
+            String errorId = event.getErrorId();
+            
+            // 요청 정보 수집
+            String method = event.getRequest().getMethod();
+            String uri = event.getRequest().getRequestURI();
+            String queryString = event.getRequest().getQueryString();
+            String userAgent = event.getRequest().getHeader("User-Agent");
+            String clientIp = getClientIpAddress(event.getRequest());
+            
+            // URL 구성
+            String fullUrl = uri;
+            if (StringUtils.hasText(queryString)) {
+                fullUrl += "?" + queryString;
+            }
+
+            // 요청 헤더 수집 (주요 헤더만)
+            StringBuilder headers = new StringBuilder();
+            Enumeration<String> headerNames = event.getRequest().getHeaderNames();
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                if (isImportantHeader(headerName)) {
+                    String headerValue = event.getRequest().getHeader(headerName);
+                    headers.append("\n  ").append(headerName).append(": ").append(headerValue);
+                }
+            }
+
+            // 스택 트레이스 생성
+            String stackTrace = getStackTrace(exception);
+
+            String message = String.format("🚨 서버 에러 발생 - [%s]\n" +
+                            "🔍 에러 ID: %s\n" +
+                            "📅 발생 시각: %s\n" +
+                            "🌐 요청: %s %s\n" +
+                            "🖥️ 클라이언트 IP: %s\n" +
+                            "🔧 User-Agent: %s\n" +
+                            "📋 에러 메시지: %s\n" +
+                            "📄 헤더 정보:%s\n" +
+                            "📚 스택 트레이스:\n%s",
+                    exception.getClass().getSimpleName(),
+                    errorId,
+                    event.getOccurredAt().toString(),
+                    method,
+                    fullUrl,
+                    clientIp,
+                    userAgent != null ? userAgent.substring(0, Math.min(userAgent.length(), 100)) + "..." : "Unknown",
+                    exception.getMessage() != null ? exception.getMessage() : "메시지 없음",
+                    headers.toString(),
+                    stackTrace
+            );
+
+            ERROR_LOGGER.error(message);
+            log.info("에러 알림 전송됨 - 에러 ID: {}, 예외: {}", errorId, exception.getClass().getSimpleName());
+
+        } catch (Exception e) {
+            log.error("에러 알림 처리 중 오류 발생", e);
+        }
+    }
+
+    private String getClientIpAddress(jakarta.servlet.http.HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(xForwardedFor)) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (StringUtils.hasText(xRealIp)) {
+            return xRealIp;
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private boolean isImportantHeader(String headerName) {
+        String lowerHeaderName = headerName.toLowerCase();
+        return lowerHeaderName.equals("content-type") ||
+               lowerHeaderName.equals("authorization") ||
+               lowerHeaderName.equals("x-forwarded-for") ||
+               lowerHeaderName.equals("x-real-ip") ||
+               lowerHeaderName.equals("host") ||
+               lowerHeaderName.equals("origin") ||
+               lowerHeaderName.equals("referer");
+    }
+
+    private String getStackTrace(Exception exception) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        exception.printStackTrace(pw);
+        
+        String fullStackTrace = sw.toString();
+        
+        // 스택 트레이스가 너무 길면 처음 20줄만 표시
+        String[] lines = fullStackTrace.split("\n");
+        if (lines.length > 20) {
+            StringBuilder truncated = new StringBuilder();
+            for (int i = 0; i < 20; i++) {
+                truncated.append(lines[i]).append("\n");
+            }
+            truncated.append("... (").append(lines.length - 20).append("줄 생략)");
+            return truncated.toString();
+        }
+        
+        return fullStackTrace;
+    }
+}

--- a/src/main/java/com/marimo/server/global/notification/FailedNotificationRecord.java
+++ b/src/main/java/com/marimo/server/global/notification/FailedNotificationRecord.java
@@ -1,0 +1,157 @@
+package com.marimo.server.global.notification;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FailedNotificationRecord {
+
+    private final String id;                    // 고유 ID (UUID)
+    private final Instant timestamp;            // 실패 시각
+    private final String traceId;               // 요청 추적 ID
+    private final String logLevel;              // 로그 레벨 (ERROR, WARN)
+    private final String loggerName;            // 로거 이름
+    private final String message;               // 에러 메시지
+    private final String exceptionClass;       // 예외 클래스명
+    private final String exceptionMessage;     // 예외 메시지
+    private final String stackTrace;           // 스택트레이스
+
+    // MDC 정보
+    private final String clientIp;
+    private final String requestURI;
+    private final String requestParams;
+    private final String requestHeaders;
+    private final String requestBody;
+
+    // 실패 정보
+    private final String failureReason;        // 실패 사유 ("SLACK_FAILED", "DISCORD_FAILED", "ALL_FAILED")
+    private final boolean slackFailed;         // Slack 실패 여부
+    private final boolean discordFailed;       // Discord 실패 여부
+
+    // 재시도 정보
+    private final int retryCount;              // 재시도 횟수
+    private final Instant lastRetryTime;      // 마지막 재시도 시각
+    private final boolean processed;          // 처리 완료 여부
+
+    public static FailedNotificationRecord fromLoggingEvent(
+            ch.qos.logback.classic.spi.ILoggingEvent event,
+            String failureReason,
+            boolean slackFailed,
+            boolean discordFailed
+    ) {
+        Map<String, String> mdcMap = event.getMDCPropertyMap();
+
+        String exceptionClass = null;
+        String exceptionMessage = null;
+        String stackTrace = null;
+
+        if (event.getThrowableProxy() != null) {
+            exceptionClass = event.getThrowableProxy().getClassName();
+            exceptionMessage = event.getThrowableProxy().getMessage();
+            stackTrace = buildStackTrace(event.getThrowableProxy());
+        }
+
+        return FailedNotificationRecord.builder()
+                .id(java.util.UUID.randomUUID().toString())
+                .timestamp(Instant.ofEpochMilli(event.getTimeStamp()))
+                .traceId(mdcMap.getOrDefault("traceId", "N/A"))
+                .logLevel(event.getLevel().toString())
+                .loggerName(event.getLoggerName())
+                .message(event.getFormattedMessage())
+                .exceptionClass(exceptionClass)
+                .exceptionMessage(exceptionMessage)
+                .stackTrace(stackTrace)
+                .clientIp(mdcMap.getOrDefault("clientIp", "N/A"))
+                .requestURI(mdcMap.getOrDefault("requestURI", "N/A"))
+                .requestParams(mdcMap.getOrDefault("requestParams", "N/A"))
+                .requestHeaders(mdcMap.getOrDefault("requestHeaders", "N/A"))
+                .requestBody(mdcMap.getOrDefault("requestBody", "N/A"))
+                .failureReason(failureReason)
+                .slackFailed(slackFailed)
+                .discordFailed(discordFailed)
+                .retryCount(0)
+                .lastRetryTime(null)
+                .processed(false)
+                .build();
+    }
+
+    public FailedNotificationRecord withRetryInfo(int retryCount, Instant lastRetryTime) {
+        return FailedNotificationRecord.builder()
+                .id(this.id)
+                .timestamp(this.timestamp)
+                .traceId(this.traceId)
+                .logLevel(this.logLevel)
+                .loggerName(this.loggerName)
+                .message(this.message)
+                .exceptionClass(this.exceptionClass)
+                .exceptionMessage(this.exceptionMessage)
+                .stackTrace(this.stackTrace)
+                .clientIp(this.clientIp)
+                .requestURI(this.requestURI)
+                .requestParams(this.requestParams)
+                .requestHeaders(this.requestHeaders)
+                .requestBody(this.requestBody)
+                .failureReason(this.failureReason)
+                .slackFailed(this.slackFailed)
+                .discordFailed(this.discordFailed)
+                .retryCount(retryCount)
+                .lastRetryTime(lastRetryTime)
+                .processed(this.processed)
+                .build();
+    }
+
+    public FailedNotificationRecord markAsProcessed() {
+        return FailedNotificationRecord.builder()
+                .id(this.id)
+                .timestamp(this.timestamp)
+                .traceId(this.traceId)
+                .logLevel(this.logLevel)
+                .loggerName(this.loggerName)
+                .message(this.message)
+                .exceptionClass(this.exceptionClass)
+                .exceptionMessage(this.exceptionMessage)
+                .stackTrace(this.stackTrace)
+                .clientIp(this.clientIp)
+                .requestURI(this.requestURI)
+                .requestParams(this.requestParams)
+                .requestHeaders(this.requestHeaders)
+                .requestBody(this.requestBody)
+                .failureReason(this.failureReason)
+                .slackFailed(this.slackFailed)
+                .discordFailed(this.discordFailed)
+                .retryCount(this.retryCount)
+                .lastRetryTime(this.lastRetryTime)
+                .processed(true)
+                .build();
+    }
+
+    private static String buildStackTrace(ch.qos.logback.classic.spi.IThrowableProxy throwableProxy) {
+        StringBuilder sb = new StringBuilder();
+
+        while (throwableProxy != null) {
+            sb.append(throwableProxy.getClassName())
+                    .append(": ")
+                    .append(throwableProxy.getMessage())
+                    .append("\n");
+
+            var stackTraceElements = throwableProxy.getStackTraceElementProxyArray();
+            int limit = Math.min(stackTraceElements.length, 10);
+
+            for (int i = 0; i < limit; i++) {
+                sb.append("    at ").append(stackTraceElements[i].getSTEAsString()).append("\n");
+            }
+
+            throwableProxy = throwableProxy.getCause();
+            if (throwableProxy != null) {
+                sb.append("Caused by: ");
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/marimo/server/global/notification/NotificationHealthCheckService.java
+++ b/src/main/java/com/marimo/server/global/notification/NotificationHealthCheckService.java
@@ -1,0 +1,435 @@
+package com.marimo.server.global.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.marimo.server.global.webhook.DiscordWebhookAdapter;
+import com.marimo.server.global.webhook.Embed;
+import com.marimo.server.global.webhook.ExecuteWebhookRequest;
+import com.marimo.server.global.webhook.SlackAttachment;
+import com.marimo.server.global.webhook.SlackWebhookAdapter;
+import com.marimo.server.global.webhook.SlackWebhookRequest;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationHealthCheckService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule());
+
+    @Value("${discord.webhook-url.prod-error:}")
+    private String discordWebhookUrl;
+
+    @Value("${slack.webhook-url.prod-error:}")
+    private String slackWebhookUrl;
+
+    @Value("${logging.location:./logs}")
+    private String logLocation;
+
+    private final String username = "this-is-marimo-bot";
+    private final String avatarUrl = "https://avatars.githubusercontent.com/u/81475587?v=4";
+
+    @Scheduled(fixedDelay = 300000) // 5분마다 실행
+    public void performHealthCheck() {
+        log.debug("🔍 알림 서비스 Health Check 시작...");
+
+        boolean slackHealthy = checkSlackHealth();
+        boolean discordHealthy = checkDiscordHealth();
+
+        log.info("📊 Health Check 결과 - Slack: {}, Discord: {}",
+                slackHealthy ? "✅ 정상" : "❌ 장애",
+                discordHealthy ? "✅ 정상" : "❌ 장애");
+
+        // 둘 다 복구되었거나, 하나라도 복구되었다면 실패 알림 재전송 시도
+        if (slackHealthy || discordHealthy) {
+            processFailedNotifications(slackHealthy, discordHealthy);
+        }
+    }
+
+    private boolean checkSlackHealth() {
+        if (slackWebhookUrl == null || slackWebhookUrl.isEmpty() || slackWebhookUrl.contains("YOUR_")) {
+            log.debug("Slack 웹훅 URL이 설정되지 않음");
+            return false;
+        }
+
+        try {
+            SlackWebhookAdapter adapter = new SlackWebhookAdapter(slackWebhookUrl);
+            SlackWebhookRequest healthCheckRequest = new SlackWebhookRequest(
+                    username, avatarUrl, "🩺 Health Check - 무시하세요"
+            );
+
+            SlackAttachment attachment = new SlackAttachment(
+                    "good",
+                    "시스템 상태 확인",
+                    "알림 시스템 정상 작동 중입니다.",
+                    String.valueOf(Instant.now().getEpochSecond())
+            );
+            healthCheckRequest.addAttachment(attachment);
+
+            return executeHealthCheck(adapter, healthCheckRequest);
+
+        } catch (Exception e) {
+            log.debug("Slack Health Check 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean checkDiscordHealth() {
+        if (discordWebhookUrl == null || discordWebhookUrl.isEmpty() || discordWebhookUrl.contains("YOUR_")) {
+            log.debug("Discord 웹훅 URL이 설정되지 않음");
+            return false;
+        }
+
+        try {
+            DiscordWebhookAdapter adapter = new DiscordWebhookAdapter(discordWebhookUrl);
+            ExecuteWebhookRequest healthCheckRequest = new ExecuteWebhookRequest(username, avatarUrl);
+
+            Embed embed = new Embed(
+                    "🩺 Health Check - 무시하세요",
+                    "알림 시스템 정상 작동 중입니다.",
+                    0x00FF00, // 녹색
+                    null
+            );
+            healthCheckRequest.addEmbed(embed);
+
+            return executeHealthCheck(adapter, healthCheckRequest);
+
+        } catch (Exception e) {
+            log.debug("Discord Health Check 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean executeHealthCheck(Object adapter, Object request) {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean success = new AtomicBoolean(false);
+
+        Callback callback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                success.set(false);
+                latch.countDown();
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    success.set(response.isSuccessful());
+                } finally {
+                    latch.countDown();
+                }
+            }
+        };
+
+        try {
+            if (adapter instanceof SlackWebhookAdapter slackAdapter) {
+                slackAdapter.execute((SlackWebhookRequest) request, callback);
+            } else if (adapter instanceof DiscordWebhookAdapter discordAdapter) {
+                discordAdapter.execute((ExecuteWebhookRequest) request, callback);
+            }
+
+            // 최대 10초 대기
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
+            return completed && success.get();
+
+        } catch (Exception e) {
+            log.debug("Health Check 실행 중 에러: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private void processFailedNotifications(boolean slackHealthy, boolean discordHealthy) {
+        log.info("🔄 실패 알림 재전송 시작 - Slack: {}, Discord: {}", slackHealthy, discordHealthy);
+
+        try {
+            List<FailedNotificationRecord> failedRecords = loadFailedNotifications();
+
+            if (failedRecords.isEmpty()) {
+                log.debug("재전송할 실패 알림이 없습니다.");
+                return;
+            }
+
+            log.info("📋 재전송할 실패 알림 {}개 발견", failedRecords.size());
+
+            for (FailedNotificationRecord record : failedRecords) {
+                if (record.isProcessed()) {
+                    continue; // 이미 처리된 알림은 건너뛰기
+                }
+
+                boolean shouldRetry = false;
+                boolean useSlackFirst = slackHealthy; // Slack이 복구되었다면 우선 사용
+
+                // 재전송 조건 확인
+                if (record.isSlackFailed() && record.isDiscordFailed()) {
+                    // 둘 다 실패한 경우: 하나라도 복구되면 재전송
+                    shouldRetry = slackHealthy || discordHealthy;
+                } else if (record.isSlackFailed() && !record.isDiscordFailed()) {
+                    // Slack만 실패한 경우: Slack이 복구되면 재전송
+                    shouldRetry = slackHealthy;
+                } else if (!record.isSlackFailed() && record.isDiscordFailed()) {
+                    // Discord만 실패한 경우: Discord가 복구되면 재전송
+                    shouldRetry = discordHealthy;
+                    useSlackFirst = false; // Discord 복구 상황이므로 Discord 사용
+                }
+
+                if (shouldRetry) {
+                    retryFailedNotification(record, useSlackFirst, slackHealthy, discordHealthy);
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("실패 알림 재전송 중 에러 발생", e);
+        }
+    }
+
+    private List<FailedNotificationRecord> loadFailedNotifications() {
+        List<FailedNotificationRecord> records = new ArrayList<>();
+
+        try {
+            String failedNotificationPath = logLocation + "/failed-notifications";
+            File directory = new File(failedNotificationPath);
+
+            if (!directory.exists()) {
+                return records;
+            }
+
+            File[] files = directory.listFiles(
+                    (dir, name) -> name.startsWith("failed-notifications-") && name.endsWith(".json"));
+
+            if (files == null) {
+                return records;
+            }
+
+            // 최근 7일간의 파일만 처리
+            for (File file : Arrays.stream(files)
+                    .filter(f -> isRecentFile(f.getName()))
+                    .toArray(File[]::new)) {
+
+                try {
+                    List<String> lines = Files.readAllLines(file.toPath());
+
+                    for (String line : lines) {
+                        if (line.trim().isEmpty()) {
+                            continue;
+                        }
+
+                        FailedNotificationRecord record = OBJECT_MAPPER.readValue(line, FailedNotificationRecord.class);
+                        records.add(record);
+                    }
+                } catch (Exception e) {
+                    log.warn("실패 알림 파일 읽기 실패: {}", file.getName(), e);
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("실패 알림 로드 중 에러 발생", e);
+        }
+
+        return records;
+    }
+
+    private boolean isRecentFile(String fileName) {
+        // 간단한 날짜 확인: 최근 7일 이내의 파일만 처리
+        // 실제로는 파일명에서 날짜를 파싱해서 확인해야 하지만, 간소화
+        return true;
+    }
+
+    private void retryFailedNotification(
+            FailedNotificationRecord record,
+            boolean useSlackFirst,
+            boolean slackHealthy,
+            boolean discordHealthy
+    ) {
+        log.info("🔄 알림 재전송 시도 - ID: {}, TraceID: {}, 우선순위: {}",
+                record.getId(), record.getTraceId(), useSlackFirst ? "Slack" : "Discord");
+
+        try {
+            if (useSlackFirst && slackHealthy) {
+                retrySlackNotification(record);
+            } else if (discordHealthy) {
+                retryDiscordNotification(record, true); // fallback 표시
+            } else {
+                log.warn("재전송 불가 - 복구된 서비스가 없음: {}", record.getId());
+            }
+
+        } catch (Exception e) {
+            log.error("알림 재전송 중 에러 발생 - ID: {}", record.getId(), e);
+        }
+    }
+
+    private void retrySlackNotification(FailedNotificationRecord record) {
+        SlackWebhookAdapter adapter = new SlackWebhookAdapter(slackWebhookUrl);
+
+        SlackWebhookRequest request = new SlackWebhookRequest(
+                username, avatarUrl, "🔄 *[재전송] MARIMO SERVER ERROR*"
+        );
+
+        SlackAttachment attachment = new SlackAttachment(
+                "danger",
+                "[재전송] " + (record.getExceptionClass() != null ? record.getExceptionClass() : "Error occurred!"),
+                "원본 발생 시각: " + record.getTimestamp() + "\n" + record.getMessage(),
+                String.valueOf(record.getTimestamp().getEpochSecond())
+        );
+
+        request.addAttachment(attachment);
+
+        Callback callback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                log.warn("재전송 실패 (Slack) - ID: {}", record.getId(), e);
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        log.info("✅ 재전송 성공 (Slack) - ID: {}", record.getId());
+                        markAsProcessed(record);
+                    } else {
+                        log.warn("재전송 실패 (Slack HTTP {}) - ID: {}", response.code(), record.getId());
+                    }
+                }
+            }
+        };
+
+        adapter.execute(request, callback);
+    }
+
+    private void retryDiscordNotification(FailedNotificationRecord record, boolean isFallback) {
+        DiscordWebhookAdapter adapter = new DiscordWebhookAdapter(discordWebhookUrl);
+
+        ExecuteWebhookRequest request = new ExecuteWebhookRequest(username, avatarUrl);
+
+        String title = "[재전송] " + (record.getExceptionClass() != null ? record.getExceptionClass() : "Error occurred!");
+        if (isFallback) {
+            title += " 🔄 [Slack Fallback]";
+        }
+
+        Embed embed = new Embed(
+                title,
+                "원본 발생 시각: " + record.getTimestamp() + "\n" + record.getMessage(),
+                0xFF0000, // 빨간색
+                null
+        );
+
+        request.addEmbed(embed);
+
+        Callback callback = new Callback() {
+            @Override
+            public void onFailure(@NotNull Call call, @NotNull IOException e) {
+                log.warn("재전송 실패 (Discord) - ID: {}", record.getId(), e);
+            }
+
+            @Override
+            public void onResponse(@NotNull Call call, @NotNull Response response) {
+                try (response) {
+                    if (response.isSuccessful()) {
+                        log.info("✅ 재전송 성공 (Discord) - ID: {}", record.getId());
+                        markAsProcessed(record);
+                    } else {
+                        log.warn("재전송 실패 (Discord HTTP {}) - ID: {}", response.code(), record.getId());
+                    }
+                }
+            }
+        };
+
+        adapter.execute(request, callback);
+    }
+
+    private void markAsProcessed(FailedNotificationRecord record) {
+        try {
+            // 처리 완료된 레코드로 업데이트
+            FailedNotificationRecord processedRecord = record.markAsProcessed();
+
+            // 원본 파일에서 해당 레코드를 찾아서 업데이트
+            updateFailedNotificationFile(record, processedRecord);
+
+            log.info("📝 알림 처리 완료 표시 - ID: {}", record.getId());
+        } catch (Exception e) {
+            log.error("알림 처리 완료 표시 중 에러 발생 - ID: {}", record.getId(), e);
+        }
+    }
+
+    private void updateFailedNotificationFile(FailedNotificationRecord originalRecord,
+                                              FailedNotificationRecord processedRecord) {
+        try {
+            String failedNotificationPath = logLocation + "/failed-notifications";
+            File directory = new File(failedNotificationPath);
+
+            if (!directory.exists()) {
+                return;
+            }
+
+            File[] files = directory.listFiles((dir, name) ->
+                    name.startsWith("failed-notifications-") && name.endsWith(".json"));
+
+            if (files == null) {
+                return;
+            }
+
+            // 각 파일에서 해당 레코드를 찾아서 업데이트
+            for (File file : files) {
+                try {
+                    List<String> lines = Files.readAllLines(file.toPath());
+                    List<String> updatedLines = new ArrayList<>();
+                    boolean updated = false;
+
+                    for (String line : lines) {
+                        if (line.trim().isEmpty()) {
+                            updatedLines.add(line);
+                            continue;
+                        }
+
+                        try {
+                            FailedNotificationRecord record = OBJECT_MAPPER.readValue(line,
+                                    FailedNotificationRecord.class);
+                            if (record.getId().equals(originalRecord.getId())) {
+                                // 해당 레코드를 처리 완료된 것으로 교체
+                                String updatedJson = OBJECT_MAPPER.writeValueAsString(processedRecord);
+                                updatedLines.add(updatedJson);
+                                updated = true;
+                            } else {
+                                updatedLines.add(line);
+                            }
+                        } catch (Exception e) {
+                            // 파싱 실패한 라인은 그대로 유지
+                            updatedLines.add(line);
+                        }
+                    }
+
+                    // 파일이 업데이트된 경우에만 다시 쓰기
+                    if (updated) {
+                        Files.write(file.toPath(), updatedLines);
+                        log.debug("파일 업데이트 완료: {}", file.getName());
+                        break; // 찾았으므로 다른 파일은 확인하지 않음
+                    }
+
+                } catch (Exception e) {
+                    log.warn("실패 알림 파일 업데이트 실패: {}", file.getName(), e);
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("실패 알림 파일 업데이트 중 에러 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/marimo/server/global/notification/NotificationTestController.java
+++ b/src/main/java/com/marimo/server/global/notification/NotificationTestController.java
@@ -1,0 +1,223 @@
+package com.marimo.server.global.notification;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import com.marimo.server.global.circuitbreaker.CircuitBreakerStatus;
+import com.marimo.server.global.logging.FallbackNotificationAppender;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/test/notification")
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationTestController {
+
+    private final NotificationHealthCheckService healthCheckService;
+
+    @PostMapping("/error")
+    public ResponseEntity<String> testErrorNotification() {
+        log.error("🧪 테스트 에러 알림 - 이것은 테스트용 에러입니다!");
+        return ResponseEntity.ok("테스트 에러 알림이 전송되었습니다.");
+    }
+
+    @PostMapping("/exception")
+    public ResponseEntity<String> testExceptionNotification() {
+        try {
+            throw new RuntimeException("테스트용 예외입니다!");
+        } catch (Exception e) {
+            log.error("🧪 테스트 예외 알림", e);
+        }
+        return ResponseEntity.ok("테스트 예외 알림이 전송되었습니다.");
+    }
+
+    @PostMapping("/health-check")
+    public ResponseEntity<String> triggerHealthCheck() {
+        try {
+            healthCheckService.performHealthCheck();
+            return ResponseEntity.ok("Health Check가 수동으로 실행되었습니다.");
+        } catch (Exception e) {
+            log.error("Health Check 수동 실행 중 에러 발생", e);
+            return ResponseEntity.status(500).body("Health Check 실행 중 에러가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/circuit-breaker/status")
+    public ResponseEntity<Map<String, Object>> getCircuitBreakerStatus() {
+        try {
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            Logger rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+
+            FallbackNotificationAppender fallbackAppender = null;
+            var appenderIterator = rootLogger.iteratorForAppenders();
+
+            while (appenderIterator.hasNext()) {
+                var appender = appenderIterator.next();
+                if (appender.getName().equals("ASYNC_FALLBACK")) {
+                    ch.qos.logback.classic.AsyncAppender asyncAppender =
+                            (ch.qos.logback.classic.AsyncAppender) appender;
+
+                    var asyncAppenderIterator = asyncAppender.iteratorForAppenders();
+                    while (asyncAppenderIterator.hasNext()) {
+                        var subAppender = asyncAppenderIterator.next();
+                        if (subAppender instanceof FallbackNotificationAppender) {
+                            fallbackAppender = (FallbackNotificationAppender) subAppender;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (fallbackAppender == null) {
+                return ResponseEntity.status(404).body(Map.of(
+                        "error", "FallbackNotificationAppender를 찾을 수 없습니다."
+                ));
+            }
+
+            CircuitBreakerStatus status = fallbackAppender.getCircuitBreaker().getStatus();
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("state", status.getState());
+            response.put("totalCalls", status.getTotalCalls());
+            response.put("failedCalls", status.getFailedCalls());
+            response.put("successfulCalls", status.getSuccessfulCalls());
+            response.put("consecutiveFailures", status.getConsecutiveFailures());
+            response.put("consecutiveSuccesses", status.getConsecutiveSuccesses());
+            response.put("failureRate", status.getFailureRate());
+            response.put("lastFailureTime", status.getLastFailureTime());
+            response.put("lastSuccessTime", status.getLastSuccessTime());
+            response.put("lastStateChangeTime", status.getLastStateChangeTime());
+
+            return ResponseEntity.ok(response);
+
+        } catch (Exception e) {
+            log.error("Circuit Breaker 상태 조회 중 에러 발생", e);
+            return ResponseEntity.status(500).body(Map.of(
+                    "error", "Circuit Breaker 상태 조회 중 에러가 발생했습니다."
+            ));
+        }
+    }
+
+    @PostMapping("/circuit-breaker/reset")
+    public ResponseEntity<String> resetCircuitBreaker() {
+        try {
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            Logger rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+
+            FallbackNotificationAppender fallbackAppender = null;
+            var appenderIterator = rootLogger.iteratorForAppenders();
+
+            while (appenderIterator.hasNext()) {
+                var appender = appenderIterator.next();
+                if (appender.getName().equals("ASYNC_FALLBACK")) {
+                    ch.qos.logback.classic.AsyncAppender asyncAppender =
+                            (ch.qos.logback.classic.AsyncAppender) appender;
+
+                    var asyncAppenderIterator = asyncAppender.iteratorForAppenders();
+                    while (asyncAppenderIterator.hasNext()) {
+                        var subAppender = asyncAppenderIterator.next();
+                        if (subAppender instanceof FallbackNotificationAppender) {
+                            fallbackAppender = (FallbackNotificationAppender) subAppender;
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if (fallbackAppender == null) {
+                return ResponseEntity.status(404).body("FallbackNotificationAppender를 찾을 수 없습니다.");
+            }
+
+            fallbackAppender.getCircuitBreaker().reset();
+            return ResponseEntity.ok("Circuit Breaker가 리셋되었습니다.");
+
+        } catch (Exception e) {
+            log.error("Circuit Breaker 리셋 중 에러 발생", e);
+            return ResponseEntity.status(500).body("Circuit Breaker 리셋 중 에러가 발생했습니다.");
+        }
+    }
+
+    @GetMapping("/failed-notifications/count")
+    public ResponseEntity<Map<String, Object>> getFailedNotificationCount() {
+        // 실제로는 FailedNotificationAppender에서 통계를 가져와야 하지만,
+        // 간소화를 위해 현재는 기본 응답만 제공
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "실패 알림 통계 조회 기능은 추후 구현 예정입니다.");
+        response.put("note", "현재는 로그 파일에서 직접 확인할 수 있습니다: logs/failed-notifications/");
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/multi-error-test")
+    public ResponseEntity<String> testMultipleErrors() {
+        log.info("다중 에러 테스트 - Circuit Breaker 상태 전환 테스트");
+
+        // Circuit Breaker를 OPEN 상태로 만들기 위한 연속 에러 생성
+        for (int i = 1; i <= 6; i++) {
+            try {
+                throw new RuntimeException("🔄 Circuit Breaker 테스트 에러 #" + i + " - " +
+                        "5회 실패 후 OPEN 상태로 전환됩니다.");
+            } catch (Exception e) {
+                log.error("테스트 에러 #{}: {}", i, e.getMessage(), e);
+            }
+
+            // 약간의 지연
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        return ResponseEntity.ok("✅ 다중 에러 테스트 완료. Circuit Breaker 상태를 확인하세요.");
+    }
+
+    @PostMapping("/custom-error")
+    public ResponseEntity<String> testCustomError() {
+        log.info("커스텀 에러 테스트 API 호출됨");
+        try {
+            // 의도적으로 NullPointerException 발생
+            String nullString = null;
+            int length = nullString.length();
+        } catch (Exception e) {
+            log.error("커스텀 에러가 발생했습니다: {}", e.getMessage(), e);
+            throw new RuntimeException("NullPointerException으로 인한 에러입니다.", e);
+        }
+        return ResponseEntity.ok("이 코드는 실행되지 않습니다.");
+    }
+
+    @PostMapping("/order-notification")
+    public ResponseEntity<String> testOrderNotification(
+            @RequestParam(defaultValue = "청첩장") String orderType,
+            @RequestParam(defaultValue = "테스트고객") String customerName
+    ) {
+        try {
+            // ORDER_NOTIFICATION 로거를 직접 사용하여 테스트 알림 전송
+            org.slf4j.Logger orderLogger = org.slf4j.LoggerFactory.getLogger("ORDER_NOTIFICATION");
+            String message = String.format("🧪 [주문 성공] 테스트 주문 알림 - %s 주문\n" +
+                            "📋 주문자: %s\n" +
+                            "⚡ 알림 경로: Slack → Discord → 파일저장 우선순위로 전송됩니다.",
+                    orderType,
+                    customerName
+            );
+            orderLogger.info(message);
+
+            return ResponseEntity.ok("주문 알림 테스트가 전송되었습니다. (" + orderType + " - " + customerName + ")");
+        } catch (Exception e) {
+            log.error("주문 알림 테스트 중 에러 발생", e);
+            return ResponseEntity.status(500).body("주문 알림 테스트 중 에러가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/marimo/server/global/notification/OrderNotificationService.java
+++ b/src/main/java/com/marimo/server/global/notification/OrderNotificationService.java
@@ -1,0 +1,147 @@
+package com.marimo.server.global.notification;
+
+import com.marimo.server.domain.order.dto.request.InvitationOrderRequest;
+import com.marimo.server.domain.order.dto.request.PreVideoOrderRequest;
+import com.marimo.server.domain.order.dto.request.SelectedOption;
+import com.marimo.server.domain.order.dto.response.OrderResponse;
+import com.marimo.server.domain.product.entity.InvitationEntity;
+import com.marimo.server.domain.product.entity.InvitationOptionEntity;
+import com.marimo.server.domain.product.entity.PreVideoEntity;
+import com.marimo.server.domain.product.repository.InvitationOptionRepository;
+import com.marimo.server.domain.product.repository.InvitationRepository;
+import com.marimo.server.domain.product.repository.PreVideoRepository;
+import com.marimo.server.global.event.InvitationOrderCreatedEvent;
+import com.marimo.server.global.event.PreVideoOrderCreatedEvent;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderNotificationService {
+
+    private static final Logger ORDER_LOGGER = LoggerFactory.getLogger("ORDER_NOTIFICATION");
+
+    private final InvitationRepository invitationRepository;
+    private final InvitationOptionRepository invitationOptionRepository;
+    private final PreVideoRepository preVideoRepository;
+
+    @EventListener
+    @Async("orderNotificationTaskExecutor")
+    public void handleInvitationOrderCreated(InvitationOrderCreatedEvent event) {
+        try {
+            InvitationOrderRequest request = event.getRequest();
+            OrderResponse response = event.getResponse();
+
+            // 1. 상품명 조회
+            InvitationEntity invitation = invitationRepository.findById(request.invitationId())
+                    .orElse(null);
+            String productName = invitation != null ? invitation.getName() : "청첩장";
+
+            // 2. 고객 정보
+            String customerName = request.customerInfo().name();
+            String phoneNumber = request.customerInfo().phoneNumber();
+            String address = buildAddress(request.customerInfo().address(), request.customerInfo().detailAddress());
+
+            // 3. 총액 계산 (옵션별 가격 * 수량)
+            long totalAmount = calculateInvitationTotalAmount(request.optionList());
+
+            // 4. 주문번호
+            String orderCode = response.orderCode();
+
+            String message = String.format("🎉 새로운 주문이 접수되었습니다 - [주문 성공] 청첩장 주문\n" +
+                            "🔖 주문번호: %s\n" +
+                            "🎨 상품명: %s\n" +
+                            "📋 주문자: %s\n" +
+                            "📞 연락처: %s\n" +
+                            "📍 배송 주소: %s\n" +
+                            "💰 주문 총액: %,d원",
+                    orderCode,
+                    productName,
+                    customerName,
+                    phoneNumber,
+                    address,
+                    totalAmount
+            );
+
+            ORDER_LOGGER.info(message);
+            log.info("청첩장 주문 알림 전송됨 - 고객: {}, 주문번호: {}", customerName, orderCode);
+
+        } catch (Exception e) {
+            log.error("청첩장 주문 알림 처리 중 오류 발생", e);
+        }
+    }
+
+    @EventListener
+    @Async("orderNotificationTaskExecutor")
+    public void handlePreVideoOrderCreated(PreVideoOrderCreatedEvent event) {
+        try {
+            PreVideoOrderRequest request = event.getRequest();
+            OrderResponse response = event.getResponse();
+
+            // 1. 상품명과 가격 조회
+            PreVideoEntity preVideo = preVideoRepository.findById(request.preVideoId())
+                    .orElse(null);
+            String productName = preVideo != null ? preVideo.getName() : "식전영상";
+            long totalAmount = preVideo != null ? preVideo.getPrice() : 0;
+
+            // 2. 고객 정보
+            String customerName = request.customerInfo().name();
+            String phoneNumber = request.customerInfo().phoneNumber();
+            String address = buildAddress(request.customerInfo().address(), request.customerInfo().detailAddress());
+
+            // 3. 주문번호
+            String orderCode = response.orderCode();
+
+            String message = String.format("🎉 새로운 주문이 접수되었습니다 - [주문 성공] 식전영상 주문\n" +
+                            "🔖 주문번호: %s\n" +
+                            "🎬 상품명: %s\n" +
+                            "📋 주문자: %s\n" +
+                            "📞 연락처: %s\n" +
+                            "📍 배송 주소: %s\n" +
+                            "💰 주문 총액: %,d원",
+                    orderCode,
+                    productName,
+                    customerName,
+                    phoneNumber,
+                    address,
+                    totalAmount
+            );
+
+            ORDER_LOGGER.info(message);
+            log.info("식전영상 주문 알림 전송됨 - 고객: {}, 주문번호: {}", customerName, orderCode);
+
+        } catch (Exception e) {
+            log.error("식전영상 주문 알림 처리 중 오류 발생", e);
+        }
+    }
+
+    private long calculateInvitationTotalAmount(List<SelectedOption> optionList) {
+        long totalAmount = 0;
+
+        for (SelectedOption selectedOption : optionList) {
+            InvitationOptionEntity option = invitationOptionRepository.findById(selectedOption.optionId())
+                    .orElse(null);
+
+            if (option != null) {
+                totalAmount += (long) option.getPrice() * selectedOption.quantity();
+            }
+        }
+
+        return totalAmount;
+    }
+
+    private String buildAddress(String address, String detailAddress) {
+        if (StringUtils.hasText(detailAddress)) {
+            return address + " " + detailAddress;
+        }
+        return address;
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/DiscordWebhookAdapter.java
+++ b/src/main/java/com/marimo/server/global/webhook/DiscordWebhookAdapter.java
@@ -1,0 +1,45 @@
+package com.marimo.server.global.webhook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marimo.server.global.exception.BusinessException;
+import com.marimo.server.global.exception.ErrorType;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+@RequiredArgsConstructor
+@Slf4j
+public class DiscordWebhookAdapter {
+
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient();
+
+    private final String webhookUrl;
+
+    public void execute(ExecuteWebhookRequest message, Callback callback) {
+        String json;
+
+        try {
+            json = OBJECT_MAPPER.writeValueAsString(message);
+        } catch (IOException e) {
+            log.error("Discord 웹훅 요청 직렬화 실패", e);
+            throw new BusinessException(ErrorType.INTERNAL_SERVER_ERROR);
+        }
+
+        RequestBody body = RequestBody.create(json, JSON_MEDIA_TYPE);
+        Request request = new Request.Builder()
+                .url(webhookUrl)
+                .post(body)
+                .build();
+
+        Call call = OK_HTTP_CLIENT.newCall(request);
+        call.enqueue(callback);
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/Embed.java
+++ b/src/main/java/com/marimo/server/global/webhook/Embed.java
@@ -1,0 +1,29 @@
+package com.marimo.server.global.webhook;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class Embed {
+
+    private final String title;
+    private final String description;
+    private final Integer color;
+    private final String timestamp;
+    private final List<Field> fields = new ArrayList<>();
+
+    public Embed(String title, String description, Integer color, String timestamp) {
+        this.title = title;
+        this.description = description;
+        this.color = color;
+        this.timestamp = timestamp;
+    }
+
+    public void addField(Field field) {
+        this.fields.add(field);
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/ExecuteWebhookRequest.java
+++ b/src/main/java/com/marimo/server/global/webhook/ExecuteWebhookRequest.java
@@ -1,0 +1,22 @@
+package com.marimo.server.global.webhook;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ExecuteWebhookRequest {
+
+    private final String username;
+    private final String avatar_url;
+    private final List<Embed> embeds = new ArrayList<>();
+
+    public ExecuteWebhookRequest(String username, String avatar_url) {
+        this.username = username;
+        this.avatar_url = avatar_url;
+    }
+
+    public void addEmbed(Embed embed) {
+        this.embeds.add(embed);
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/Field.java
+++ b/src/main/java/com/marimo/server/global/webhook/Field.java
@@ -1,0 +1,17 @@
+package com.marimo.server.global.webhook;
+
+import lombok.Getter;
+
+@Getter
+public class Field {
+
+    private final String name;
+    private final String value;
+    private final Boolean inline;
+
+    public Field(String name, String value, Boolean inline) {
+        this.name = name;
+        this.value = value;
+        this.inline = inline;
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/SlackAttachment.java
+++ b/src/main/java/com/marimo/server/global/webhook/SlackAttachment.java
@@ -1,0 +1,29 @@
+package com.marimo.server.global.webhook;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class SlackAttachment {
+
+    private final String color;
+    private final String title;
+    private final String text;
+    private final String timestamp;
+    private final List<SlackField> fields = new ArrayList<>();
+
+    public SlackAttachment(String color, String title, String text, String timestamp) {
+        this.color = color;
+        this.title = title;
+        this.text = text;
+        this.timestamp = timestamp;
+    }
+
+    public void addField(SlackField field) {
+        this.fields.add(field);
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/SlackField.java
+++ b/src/main/java/com/marimo/server/global/webhook/SlackField.java
@@ -1,0 +1,17 @@
+package com.marimo.server.global.webhook;
+
+import lombok.Getter;
+
+@Getter
+public class SlackField {
+
+    private final String title;
+    private final String value;
+    private final Boolean short_field;  // Slack은 'short' 필드명 사용
+
+    public SlackField(String title, String value, Boolean isShort) {
+        this.title = title;
+        this.value = value;
+        this.short_field = isShort;
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/SlackWebhookAdapter.java
+++ b/src/main/java/com/marimo/server/global/webhook/SlackWebhookAdapter.java
@@ -1,0 +1,45 @@
+package com.marimo.server.global.webhook;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marimo.server.global.exception.BusinessException;
+import com.marimo.server.global.exception.ErrorType;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+@RequiredArgsConstructor
+@Slf4j
+public class SlackWebhookAdapter {
+
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.get("application/json; charset=utf-8");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final OkHttpClient OK_HTTP_CLIENT = new OkHttpClient();
+
+    private final String webhookUrl;
+
+    public void execute(SlackWebhookRequest message, Callback callback) {
+        String json;
+
+        try {
+            json = OBJECT_MAPPER.writeValueAsString(message);
+        } catch (IOException e) {
+            log.error("Slack 웹훅 요청 직렬화 실패", e);
+            throw new BusinessException(ErrorType.INTERNAL_SERVER_ERROR);
+        }
+
+        RequestBody body = RequestBody.create(json, JSON_MEDIA_TYPE);
+        Request request = new Request.Builder()
+                .url(webhookUrl)
+                .post(body)
+                .build();
+
+        Call call = OK_HTTP_CLIENT.newCall(request);
+        call.enqueue(callback);
+    }
+}

--- a/src/main/java/com/marimo/server/global/webhook/SlackWebhookRequest.java
+++ b/src/main/java/com/marimo/server/global/webhook/SlackWebhookRequest.java
@@ -1,0 +1,24 @@
+package com.marimo.server.global.webhook;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SlackWebhookRequest {
+
+    private final String username;
+    private final String icon_url;
+    private final String text;
+    private final List<SlackAttachment> attachments = new ArrayList<>();
+
+    public SlackWebhookRequest(String username, String iconUrl, String text) {
+        this.username = username;
+        this.icon_url = iconUrl;
+        this.text = text;
+    }
+
+    public void addAttachment(SlackAttachment attachment) {
+        this.attachments.add(attachment);
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -60,16 +60,20 @@
         <property name="ORDER_NOTI_DISCORD_WEBHOOK_URL" value="${DEV_ORDER_NOTI_DISCORD_WEBHOOK_URL}"/>
     </springProfile>
 
+    <!-- 서킷 브레이커 설정 -->
+    <springProperty name="CIRCUIT_BREAKER_FAILURE_THRESHOLD" source="circuit-breaker.failure-threshold"/>
+    <springProperty name="CIRCUIT_BREAKER_SUCCESS_THRESHOLD" source="circuit-breaker.success-threshold"/>
+    <springProperty name="CIRCUIT_BREAKER_TIMEOUT_DURATION" source="circuit-breaker.timeout-duration"/>
+
     <!-- 에러 알림 Appender 설정 -->
     <appender name="FALLBACK_NOTIFICATION" class="com.marimo.server.global.logging.FallbackNotificationAppender">
         <username>this-is-marimo-bot</username>
         <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
         <slackWebhookUrl>${SERVER_ERROR_SLACK_WEBHOOK_URL}</slackWebhookUrl>
         <discordWebhookUrl>${SERVER_ERROR_DISCORD_WEBHOOK_URL}</discordWebhookUrl>
-        <!-- 서킷 브레이커 설정 -->
-        <failureThreshold>5</failureThreshold>      <!-- 5회 실패 시 OPEN -->
-        <successThreshold>3</successThreshold>      <!-- 3회 성공 시 CLOSED -->
-        <timeoutDuration>60000</timeoutDuration>    <!-- 1분 후 HALF_OPEN -->
+        <failureThreshold>${CIRCUIT_BREAKER_FAILURE_THRESHOLD}</failureThreshold>
+        <successThreshold>${CIRCUIT_BREAKER_SUCCESS_THRESHOLD}</successThreshold>
+        <timeoutDuration>${CIRCUIT_BREAKER_TIMEOUT_DURATION}</timeoutDuration>
     </appender>
 
     <!-- 주문 알림 Appender 설정 -->
@@ -78,10 +82,9 @@
         <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
         <slackWebhookUrl>${ORDER_NOTI_SLACK_WEBHOOK_URL}</slackWebhookUrl>
         <discordWebhookUrl>${ORDER_NOTI_DISCORD_WEBHOOK_URL}</discordWebhookUrl>
-        <!-- 서킷 브레이커 설정 -->
-        <failureThreshold>5</failureThreshold>      <!-- 5회 실패 시 OPEN -->
-        <successThreshold>3</successThreshold>      <!-- 3회 성공 시 CLOSED -->
-        <timeoutDuration>60000</timeoutDuration>    <!-- 1분 후 HALF_OPEN -->
+        <failureThreshold>${CIRCUIT_BREAKER_FAILURE_THRESHOLD}</failureThreshold>
+        <successThreshold>${CIRCUIT_BREAKER_SUCCESS_THRESHOLD}</successThreshold>
+        <timeoutDuration>${CIRCUIT_BREAKER_TIMEOUT_DURATION}</timeoutDuration>
     </appender>
 
     <!-- 에러 알림 비동기 처리 설정 -->
@@ -110,16 +113,6 @@
 
     <!-- 운영 환경 설정 -->
     <springProfile name="prod">
-        <!-- 서버 에러 알림 전용 logger -->
-        <logger name="ERROR_NOTIFICATION" level="ERROR" additivity="false">
-            <appender-ref ref="ASYNC_FALLBACK"/>
-        </logger>
-
-        <!-- 주문 알림 전용 logger -->
-        <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
-            <appender-ref ref="ASYNC_ORDER"/>
-        </logger>
-
         <!-- marimo 애플리케이션 logger -->
         <logger name="com.marimo.server" level="INFO" additivity="false">
             <appender-ref ref="CONSOLE"/>
@@ -135,16 +128,6 @@
 
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">
-        <!-- 서버 에러 알림 전용 logger -->
-        <logger name="ERROR_NOTIFICATION" level="ERROR" additivity="false">
-            <appender-ref ref="ASYNC_FALLBACK"/>
-        </logger>
-
-        <!-- 주문 알림 전용 logger -->
-        <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
-            <appender-ref ref="ASYNC_ORDER"/>
-        </logger>
-
         <!-- marimo 애플리케이션 logger -->
         <logger name="com.marimo.server" level="DEBUG" additivity="false">
             <appender-ref ref="CONSOLE"/>
@@ -156,7 +139,7 @@
         </root>
     </springProfile>
 
-    <!-- 개발 환경 설정 -->
+    <!-- 로컬 환경 설정 -->
     <springProfile name="local">
         <!-- marimo 애플리케이션 logger -->
         <logger name="com.marimo.server" level="DEBUG" additivity="false">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,13 +5,13 @@
 
     <!-- 로그 출력 패턴 설정 -->
     <property name="CONSOLE_LOG_PATTERN"
-              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul}){faint} %clr(%5level){} %clr([%15.15thread] [%X{traceId:-NoTraceID}]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"/>
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul}){faint} %clr(%5level){} %clr(--- [%15.15thread] [%X{traceId:-NoTraceID}]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"/>
     <property name="FILE_LOG_PATTERN"
-              value="%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %5level [%15.15thread] [%X{traceId:-NoTraceID}] %-40.40logger{39} - %msg%n"/>
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %5level --- [%15.15thread] [%X{traceId:-NoTraceID}] %-40.40logger{39} : %msg%n"/>
 
     <!-- 로그 파일 경로 설정 -->
     <springProperty name="LOG_HOME_PATH" source="logging.location"/>
-    <property name="LOG_PATH" value="${LOG_HOME_PATH}/marimo-logs"/>
+    <property name="LOG_PATH" value="${LOG_HOME_PATH}/app-logs"/>
     <property name="LOG_FILE" value="${LOG_PATH}/marimo.log"/>
 
     <!-- 콘솔 로그 출력 설정 -->
@@ -25,53 +25,75 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/marimo-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <maxHistory>90</maxHistory>
+            <fileNamePattern>${LOG_PATH}/%d{yyyy-MM}/marimo_%d{yyyy-MM-dd}_%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>     <!-- 10MB 단위로 파일 분리 -->
+            <maxHistory>90</maxHistory>         <!-- 90일간 보관 -->
+            <totalSizeCap>1GB</totalSizeCap>    <!-- 전체 보관 용량 제한 -->
         </rollingPolicy>
         <encoder>
+            <charset>UTF-8</charset>
             <pattern>${FILE_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
     <!-- Discord & Slack 웹훅 URL 설정 -->
-    <springProperty name="PROD_DISCORD_WEBHOOK_URL" source="discord.webhook-url.prod-error"/>
-    <springProperty name="LOCAL_DISCORD_WEBHOOK_URL" source="discord.webhook-url.local-error"/>
-    <springProperty name="PROD_SLACK_WEBHOOK_URL" source="slack.webhook-url.prod-error"/>
-    <springProperty name="LOCAL_SLACK_WEBHOOK_URL" source="slack.webhook-url.local-error"/>
+    <springProperty name="PROD_ERROR_SLACK_WEBHOOK_URL" source="slack.webhook-url.prod.error"/>
+    <springProperty name="PROD_ERROR_DISCORD_WEBHOOK_URL" source="discord.webhook-url.prod.error"/>
+    <springProperty name="PROD_ORDER_NOTI_SLACK_WEBHOOK_URL" source="slack.webhook-url.prod.order"/>
+    <springProperty name="PROD_ORDER_NOTI_DISCORD_WEBHOOK_URL" source="discord.webhook-url.prod.order"/>
+    <springProperty name="DEV_ERROR_SLACK_WEBHOOK_URL" source="slack.webhook-url.dev.error"/>
+    <springProperty name="DEV_ERROR_DISCORD_WEBHOOK_URL" source="discord.webhook-url.dev.error"/>
+    <springProperty name="DEV_ORDER_NOTI_SLACK_WEBHOOK_URL" source="slack.webhook-url.dev.order"/>
+    <springProperty name="DEV_ORDER_NOTI_DISCORD_WEBHOOK_URL" source="discord.webhook-url.dev.order"/>
 
-    <!-- active profile에 따라 Webhook URL 설정 -->
+    <!-- active profile에 따른 웹훅 URL 설정 -->
     <springProfile name="prod">
-        <property name="DISCORD_ERROR_WEBHOOK_URL" value="${PROD_DISCORD_WEBHOOK_URL}"/>
-        <property name="SLACK_ERROR_WEBHOOK_URL" value="${PROD_SLACK_WEBHOOK_URL}"/>
+        <property name="SERVER_ERROR_SLACK_WEBHOOK_URL" value="${PROD_ERROR_SLACK_WEBHOOK_URL}"/>
+        <property name="SERVER_ERROR_DISCORD_WEBHOOK_URL" value="${PROD_ERROR_DISCORD_WEBHOOK_URL}"/>
+        <property name="ORDER_NOTI_SLACK_WEBHOOK_URL" value="${PROD_ORDER_NOTI_SLACK_WEBHOOK_URL}"/>
+        <property name="ORDER_NOTI_DISCORD_WEBHOOK_URL" value="${PROD_ORDER_NOTI_DISCORD_WEBHOOK_URL"/>
     </springProfile>
-    <springProfile name="local">
-        <property name="DISCORD_ERROR_WEBHOOK_URL" value="${LOCAL_DISCORD_WEBHOOK_URL}"/>
-        <property name="SLACK_ERROR_WEBHOOK_URL" value="${LOCAL_SLACK_WEBHOOK_URL}"/>
+    <springProfile name="dev">
+        <property name="SERVER_ERROR_SLACK_WEBHOOK_URL" value="${DEV_ERROR_SLACK_WEBHOOK_URL}"/>
+        <property name="SERVER_ERROR_DISCORD_WEBHOOK_URL" value="${DEV_ERROR_DISCORD_WEBHOOK_URL}"/>
+        <property name="ORDER_NOTI_SLACK_WEBHOOK_URL" value="${DEV_ORDER_NOTI_SLACK_WEBHOOK_URL}"/>
+        <property name="ORDER_NOTI_DISCORD_WEBHOOK_URL" value="${DEV_ORDER_NOTI_DISCORD_WEBHOOK_URL}"/>
     </springProfile>
 
-    <!-- Circuit Breaker 기반 Fallback 알림 설정 -->
+    <!-- 에러 알림 Appender 설정 -->
     <appender name="FALLBACK_NOTIFICATION" class="com.marimo.server.global.logging.FallbackNotificationAppender">
         <username>this-is-marimo-bot</username>
         <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
-        <slackWebhookUrl>${SLACK_ERROR_WEBHOOK_URL}</slackWebhookUrl>
-        <discordWebhookUrl>${DISCORD_ERROR_WEBHOOK_URL}</discordWebhookUrl>
-        <!-- Circuit Breaker 설정 -->
-        <failureThreshold>5</failureThreshold>        <!-- 5회 실패 시 OPEN -->
-        <successThreshold>3</successThreshold>        <!-- 3회 성공 시 CLOSED -->
-        <timeoutDuration>60000</timeoutDuration>      <!-- 1분 후 HALF_OPEN -->
+        <slackWebhookUrl>${SERVER_ERROR_SLACK_WEBHOOK_URL}</slackWebhookUrl>
+        <discordWebhookUrl>${SERVER_ERROR_DISCORD_WEBHOOK_URL}</discordWebhookUrl>
+        <!-- 서킷 브레이커 설정 -->
+        <failureThreshold>5</failureThreshold>      <!-- 5회 실패 시 OPEN -->
+        <successThreshold>3</successThreshold>      <!-- 3회 성공 시 CLOSED -->
+        <timeoutDuration>60000</timeoutDuration>    <!-- 1분 후 HALF_OPEN -->
     </appender>
 
-    <!-- 주문 성공 알림 Appender -->
+    <!-- 주문 알림 Appender 설정 -->
     <appender name="ORDER_NOTIFICATION" class="com.marimo.server.global.logging.OrderNotificationAppender">
         <username>this-is-marimo-bot</username>
         <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
-        <slackWebhookUrl>${SLACK_ERROR_WEBHOOK_URL}</slackWebhookUrl>
-        <discordWebhookUrl>${DISCORD_ERROR_WEBHOOK_URL}</discordWebhookUrl>
-        <!-- Circuit Breaker 설정 (에러 알림과 동일) -->
-        <failureThreshold>5</failureThreshold>        <!-- 5회 실패 시 OPEN -->
-        <successThreshold>3</successThreshold>        <!-- 3회 성공 시 CLOSED -->
-        <timeoutDuration>60000</timeoutDuration>      <!-- 1분 후 HALF_OPEN -->
+        <slackWebhookUrl>${ORDER_NOTI_SLACK_WEBHOOK_URL}</slackWebhookUrl>
+        <discordWebhookUrl>${ORDER_NOTI_DISCORD_WEBHOOK_URL}</discordWebhookUrl>
+        <!-- 서킷 브레이커 설정 -->
+        <failureThreshold>5</failureThreshold>      <!-- 5회 실패 시 OPEN -->
+        <successThreshold>3</successThreshold>      <!-- 3회 성공 시 CLOSED -->
+        <timeoutDuration>60000</timeoutDuration>    <!-- 1분 후 HALF_OPEN -->
+    </appender>
+
+    <!-- 에러 알림 비동기 처리 설정 -->
+    <appender name="ASYNC_FALLBACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FALLBACK_NOTIFICATION"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <!-- 에러 알림은 버리지 않음 -->
+        <discardingThreshold>0</discardingThreshold>
+        <!-- 애플리케이션 종료 시 대기 시간 연장 (기본값: 1000ms) -->
+        <maxFlushTime>5000</maxFlushTime>
     </appender>
 
     <!-- 주문 알림 비동기 처리 설정 -->
@@ -80,61 +102,70 @@
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>INFO</level>
         </filter>
-        <!-- 큐 크기 설정 (기본값: 256) -->
-        <queueSize>512</queueSize>
-        <!-- 큐가 가득 찰 때 로그를 버리지 않고 대기 -->
-        <neverBlock>false</neverBlock>
-    </appender>
-
-    <!-- Fallback 알림 비동기 처리 설정 -->
-    <appender name="ASYNC_FALLBACK" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FALLBACK_NOTIFICATION"/>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>ERROR</level>
-        </filter>
-        <!-- 큐 크기 설정 (기본값: 256) -->
-        <queueSize>512</queueSize>
-        <!-- 큐가 가득 찰 때 로그를 버리지 않고 대기 -->
-        <neverBlock>false</neverBlock>
+        <!-- 주문 알림은 버리지 않음 -->
+        <discardingThreshold>0</discardingThreshold>
+        <!-- 애플리케이션 종료 시 대기 시간 연장 (기본값: 1000ms) -->
+        <maxFlushTime>5000</maxFlushTime>
     </appender>
 
     <!-- 운영 환경 설정 -->
     <springProfile name="prod">
+        <!-- 서버 에러 알림 전용 logger -->
+        <logger name="ERROR_NOTIFICATION" level="ERROR" additivity="false">
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </logger>
+
         <!-- 주문 알림 전용 logger -->
         <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
             <appender-ref ref="ASYNC_ORDER"/>
         </logger>
 
-        <!-- marimo 패키지 logger 레벨 설정 -->
+        <!-- marimo 애플리케이션 logger -->
         <logger name="com.marimo.server" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_FALLBACK"/>
         </logger>
 
-        <!-- root logger 레벨 설정 -->
+        <!-- root(외부 라이브러리) logger -->
         <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_FALLBACK"/>
         </root>
     </springProfile>
 
-    <!-- 로컬 환경 설정 -->
-    <springProfile name="local">
+    <!-- 개발 환경 설정 -->
+    <springProfile name="dev">
+        <!-- 서버 에러 알림 전용 logger -->
+        <logger name="ERROR_NOTIFICATION" level="ERROR" additivity="false">
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </logger>
+
         <!-- 주문 알림 전용 logger -->
         <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
             <appender-ref ref="ASYNC_ORDER"/>
         </logger>
 
-        <!-- marimo 패키지 logger 레벨 설정 -->
+        <!-- marimo 애플리케이션 logger -->
         <logger name="com.marimo.server" level="DEBUG" additivity="false">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_FALLBACK"/>
         </logger>
 
-        <!-- root logger 레벨 설정 -->
+        <!-- root(외부 라이브러리) logger -->
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_FALLBACK"/>
+        </root>
+    </springProfile>
+
+    <!-- 개발 환경 설정 -->
+    <springProfile name="local">
+        <!-- marimo 애플리케이션 logger -->
+        <logger name="com.marimo.server" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+
+        <!-- root(외부 라이브러리) logger -->
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 로그 출력 색상 설정 -->
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- 로그 출력 패턴 설정 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%clr(%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul}){faint} %clr(%5level){} %clr([%15.15thread] [%X{traceId:-NoTraceID}]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %msg%n"/>
+    <property name="FILE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS, Asia/Seoul} %5level [%15.15thread] [%X{traceId:-NoTraceID}] %-40.40logger{39} - %msg%n"/>
+
+    <!-- 로그 파일 경로 설정 -->
+    <springProperty name="LOG_HOME_PATH" source="logging.location"/>
+    <property name="LOG_PATH" value="${LOG_HOME_PATH}/marimo-logs"/>
+    <property name="LOG_FILE" value="${LOG_PATH}/marimo.log"/>
+
+    <!-- 콘솔 로그 출력 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 로그 출력 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/marimo-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Discord & Slack 웹훅 URL 설정 -->
+    <springProperty name="PROD_DISCORD_WEBHOOK_URL" source="discord.webhook-url.prod-error"/>
+    <springProperty name="LOCAL_DISCORD_WEBHOOK_URL" source="discord.webhook-url.local-error"/>
+    <springProperty name="PROD_SLACK_WEBHOOK_URL" source="slack.webhook-url.prod-error"/>
+    <springProperty name="LOCAL_SLACK_WEBHOOK_URL" source="slack.webhook-url.local-error"/>
+
+    <!-- active profile에 따라 Webhook URL 설정 -->
+    <springProfile name="prod">
+        <property name="DISCORD_ERROR_WEBHOOK_URL" value="${PROD_DISCORD_WEBHOOK_URL}"/>
+        <property name="SLACK_ERROR_WEBHOOK_URL" value="${PROD_SLACK_WEBHOOK_URL}"/>
+    </springProfile>
+    <springProfile name="local">
+        <property name="DISCORD_ERROR_WEBHOOK_URL" value="${LOCAL_DISCORD_WEBHOOK_URL}"/>
+        <property name="SLACK_ERROR_WEBHOOK_URL" value="${LOCAL_SLACK_WEBHOOK_URL}"/>
+    </springProfile>
+
+    <!-- Circuit Breaker 기반 Fallback 알림 설정 -->
+    <appender name="FALLBACK_NOTIFICATION" class="com.marimo.server.global.logging.FallbackNotificationAppender">
+        <username>this-is-marimo-bot</username>
+        <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
+        <slackWebhookUrl>${SLACK_ERROR_WEBHOOK_URL}</slackWebhookUrl>
+        <discordWebhookUrl>${DISCORD_ERROR_WEBHOOK_URL}</discordWebhookUrl>
+        <!-- Circuit Breaker 설정 -->
+        <failureThreshold>5</failureThreshold>        <!-- 5회 실패 시 OPEN -->
+        <successThreshold>3</successThreshold>        <!-- 3회 성공 시 CLOSED -->
+        <timeoutDuration>60000</timeoutDuration>      <!-- 1분 후 HALF_OPEN -->
+    </appender>
+
+    <!-- 주문 성공 알림 Appender -->
+    <appender name="ORDER_NOTIFICATION" class="com.marimo.server.global.logging.OrderNotificationAppender">
+        <username>this-is-marimo-bot</username>
+        <avatarUrl>https://avatars.githubusercontent.com/u/81475587?v=4</avatarUrl>
+        <slackWebhookUrl>${SLACK_ERROR_WEBHOOK_URL}</slackWebhookUrl>
+        <discordWebhookUrl>${DISCORD_ERROR_WEBHOOK_URL}</discordWebhookUrl>
+        <!-- Circuit Breaker 설정 (에러 알림과 동일) -->
+        <failureThreshold>5</failureThreshold>        <!-- 5회 실패 시 OPEN -->
+        <successThreshold>3</successThreshold>        <!-- 3회 성공 시 CLOSED -->
+        <timeoutDuration>60000</timeoutDuration>      <!-- 1분 후 HALF_OPEN -->
+    </appender>
+
+    <!-- 주문 알림 비동기 처리 설정 -->
+    <appender name="ASYNC_ORDER" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="ORDER_NOTIFICATION"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <!-- 큐 크기 설정 (기본값: 256) -->
+        <queueSize>512</queueSize>
+        <!-- 큐가 가득 찰 때 로그를 버리지 않고 대기 -->
+        <neverBlock>false</neverBlock>
+    </appender>
+
+    <!-- Fallback 알림 비동기 처리 설정 -->
+    <appender name="ASYNC_FALLBACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FALLBACK_NOTIFICATION"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <!-- 큐 크기 설정 (기본값: 256) -->
+        <queueSize>512</queueSize>
+        <!-- 큐가 가득 찰 때 로그를 버리지 않고 대기 -->
+        <neverBlock>false</neverBlock>
+    </appender>
+
+    <!-- 운영 환경 설정 -->
+    <springProfile name="prod">
+        <!-- 주문 알림 전용 logger -->
+        <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
+            <appender-ref ref="ASYNC_ORDER"/>
+        </logger>
+
+        <!-- marimo 패키지 logger 레벨 설정 -->
+        <logger name="com.marimo.server" level="INFO" additivity="false">
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </logger>
+
+        <!-- root logger 레벨 설정 -->
+        <root level="INFO">
+            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </root>
+    </springProfile>
+
+    <!-- 로컬 환경 설정 -->
+    <springProfile name="local">
+        <!-- 주문 알림 전용 logger -->
+        <logger name="ORDER_NOTIFICATION" level="INFO" additivity="false">
+            <appender-ref ref="ASYNC_ORDER"/>
+        </logger>
+
+        <!-- marimo 패키지 logger 레벨 설정 -->
+        <logger name="com.marimo.server" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </logger>
+
+        <!-- root logger 레벨 설정 -->
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FALLBACK"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
# 💡 Issue
- resolved: #21 

# 📄 Description
<!-- 작업한 내용에 대해 상세하게 설명해 주세요,
코드를 첨부할 경우 permalink를 사용해 주세요 -->
- 서버 500 에러 및 주문 성공 시 Slack을 우선으로 하고, 실패 시 Discord로 fallback하는 서킷 브레이커 패턴 기반 알림 시스템을 구축했습니다.
- Slack과 Discord 모두에 장애가 발생하여 알림 자체에 실패할 시, File Storage에 실패 알림들을 보관해 두고 주기적으로 Health Check하여 장애 복구가 감지되면 저장되어 있던 알림을 재전송하도록 구현했습니다.
- 500 에러 알림의 경우 Appender, Logback, Filter를 활용하고, 주문 성공 알림의 경우 `@EventListener` + `@Async`를 활용하여 비동기로 처리하도록 구현했습니다.